### PR TITLE
R1: alts - enforce single default arm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,19 @@
 .tmp_versions/
 modules.order
 Module.symvers
+
+# CMake build directory
+build/
+cmake-build-*/
+
+# CMake cache
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+
+# IDE
+.vscode/
+.idea/
 Mkfile.old
 dkms.conf
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -883,6 +883,11 @@ goc_alts_result goc_alts_sync(goc_alt_op* ops, size_t n); /* blocking OS thread 
 
 The returned `goc_alts_result.index` is the zero-based index of the winning arm. `goc_alts_result.value` is a `goc_val_t`. For take arms, `value.ok == GOC_CLOSED` means the channel was closed rather than that a `NULL` was sent. For put arms, the winning result is always `{NULL, GOC_OK}` — `result_slot` is NULL for put entries and `wake()` skips the `result_slot` write. For a `GOC_ALT_DEFAULT` arm, the winning result is `{NULL, GOC_OK}`.
 
+**Invariants:**
+
+- **At most one `GOC_ALT_DEFAULT` arm** must be provided. If `ops` contains more than one arm with `op_kind == GOC_ALT_DEFAULT`, both functions abort with a diagnostic error message. Setting `op_kind` to `GOC_ALT_DEFAULT` requires `ch == NULL`; providing a non-NULL channel pointer with `GOC_ALT_DEFAULT` is unsupported and produces undefined behaviour.
+- **Fiber context (goc_alts only):** `goc_alts` must be called from within a fiber (i.e., `mco_running() != NULL`). Calling `goc_alts` from a bare OS thread aborts with a diagnostic error message.
+
 **Phases:**
 
 1. Shuffle `ops` to avoid starvation. A `GOC_ALT_DEFAULT` arm, if present, is excluded from the shuffle and always treated last in Phase 2.
@@ -1205,6 +1210,8 @@ The test suite is split across phase files in `tests/`, each a self-contained C 
 | P8.1 | Stack overflow: an `overflow_fiber` corrupts its own canary word then parks on `goc_take`; a `sender_fiber` calls `goc_put` to wake it; `pool_worker_fn` checks the canary before the next `mco_resume`, finds it corrupted, and calls `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT`. Two fibers are used (rather than a fiber + `goc_take_sync` from the OS thread) to guarantee the victim parks before the sender runs — with `goc_take_sync`, a race exists where the OS thread parks first and the fiber's `goc_put` rendezvouses immediately without ever suspending, so the canary check never fires. |
 | P8.2 | `goc_take` called from a bare OS thread (not a fiber) → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
 | P8.3 | `goc_put` called from a bare OS thread (not a fiber) → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
+| P8.4 | `goc_alts` called with more than one `GOC_ALT_DEFAULT` arm (from within a fiber) → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT`. A fiber is spawned via `goc_go()` to provide fiber context. |
+| P8.5 | `goc_alts_sync` called with more than one `GOC_ALT_DEFAULT` arm → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
 
 ### Running
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 ### Safety
 
-- [ ] **R1** `goc_alts` should assert `n_default_arms <= 1`
+- [x] **R1** `goc_alts` should assert `n_default_arms <= 1`
 
 - [ ] **R2** `goc_pool_destroy` should not be callable from within the pool being destroyed
 

--- a/src/alts.c
+++ b/src/alts.c
@@ -15,6 +15,7 @@
  *   Phase 7 — On resume: cancel losers, extract winner, return result.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdatomic.h>
 #include <assert.h>
@@ -117,6 +118,7 @@ goc_alts_result goc_alts(goc_alt_op *ops, size_t n) {
     mco_coro *running = mco_running();
     if (!running) {
         /* Calling goc_alts from a bare OS thread is a programming error. */
+        fprintf(stderr, "goc_alts: cannot be called from OS thread (not in fiber context)\n");
         abort();
     }
 
@@ -127,9 +129,11 @@ goc_alts_result goc_alts(goc_alt_op *ops, size_t n) {
     /* Phase 1 — Shuffle                                                    */
     /* Build a shuffled index array.  A GOC_ALT_DEFAULT arm is excluded    */
     /* from the shuffle; it is identified and placed at the end.           */
+    /* Enforce that at most one default arm is provided.                   */
     /* ------------------------------------------------------------------ */
     size_t  default_idx  = (size_t)-1;
     size_t  n_nondefault = 0;
+    size_t  n_default = 0;
     /* VLA: n is expected to be small (single digits in practice). A
      * pathologically large n could overflow the fiber's 64 KB stack; callers
      * are responsible for keeping arm counts reasonable. */
@@ -137,6 +141,11 @@ goc_alts_result goc_alts(goc_alt_op *ops, size_t n) {
 
     for (size_t i = 0; i < n; i++) {
         if (ops[i].op_kind == GOC_ALT_DEFAULT) {
+            n_default++;
+            if (n_default > 1) {
+                fprintf(stderr, "goc_alts: more than one default arm provided (got %zu)\n", n_default);
+                abort();
+            }
             default_idx = i;
         } else {
             indices[n_nondefault++] = i;
@@ -371,7 +380,10 @@ goc_alts_result goc_alts(goc_alt_op *ops, size_t n) {
     /* The woken CAS in wake() / goc_close() guarantees exactly one entry wins.
      * A NULL winner here means the protocol is broken — abort rather than
      * silently producing undefined behaviour via a NULL dereference. */
-    assert(winner != NULL && "goc_alts: no winner after wake — woken CAS invariant violated");
+    if (winner == NULL) {
+        fprintf(stderr, "goc_alts: no winner after wake — woken CAS invariant violated\n");
+        abort();
+    }
 
     /* winner must not be NULL — the runtime guarantees exactly one wake */
     void *result_val = (winner->result_slot) ? *winner->result_slot : NULL;
@@ -390,14 +402,21 @@ goc_alts_result goc_alts(goc_alt_op *ops, size_t n) {
 goc_alts_result goc_alts_sync(goc_alt_op *ops, size_t n) {
     /* ------------------------------------------------------------------ */
     /* Phase 1 — Shuffle                                                    */
+    /* Enforce that at most one default arm is provided.                   */
     /* ------------------------------------------------------------------ */
     size_t  default_idx  = (size_t)-1;
     size_t  n_nondefault = 0;
+    size_t  n_default = 0;
     /* VLA: same size constraint as goc_alts — n should be small. */
     size_t  indices[n];
 
     for (size_t i = 0; i < n; i++) {
         if (ops[i].op_kind == GOC_ALT_DEFAULT) {
+            n_default++;
+            if (n_default > 1) {
+                fprintf(stderr, "goc_alts_sync: more than one default arm provided (got %zu)\n", n_default);
+                abort();
+            }
             default_idx = i;
         } else {
             indices[n_nondefault++] = i;
@@ -638,7 +657,10 @@ goc_alts_result goc_alts_sync(goc_alt_op *ops, size_t n) {
     }
 
     /* Same invariant as goc_alts: exactly one entry must have won the woken CAS. */
-    assert(winner != NULL && "goc_alts_sync: no winner after wake — woken CAS invariant violated");
+    if (winner == NULL) {
+        fprintf(stderr, "goc_alts_sync: no winner after wake — woken CAS invariant violated\n");
+        abort();
+    }
 
     void *result_val = (winner->result_slot) ? *winner->result_slot : NULL;
     return (goc_alts_result){ .index = winner->arm_idx,

--- a/tests/test_p8_safety.c
+++ b/tests/test_p8_safety.c
@@ -48,6 +48,10 @@
  *          verified via fork + waitpid asserting SIGABRT
  *   P8.3   goc_put() called from a bare OS thread (not a fiber) → abort();
  *          verified via fork + waitpid asserting SIGABRT
+ *   P8.4   goc_alts() with multiple default arms → abort();
+ *          verified via fork + waitpid asserting SIGABRT
+ *   P8.5   goc_alts_sync() with multiple default arms → abort();
+ *          verified via fork + waitpid asserting SIGABRT
  *
  * Notes:
  *   - goc_init() is called once in the parent main() before forking, but
@@ -310,6 +314,84 @@ static void test_p8_3(void) {
 done:;
 }
 
+/* --- P8.4: goc_alts() with multiple default arms → abort() --------------- */
+
+/*
+ * p8_4_alts_fiber — fiber entry point for P8.4.
+ * Calls goc_alts() with 2 default arms, which should trigger an abort()
+ * in Phase 1 validation.
+ */
+static void p8_4_alts_fiber(void* arg) {
+    (void)arg;
+
+    goc_alt_op ops[2] = {
+        { .op_kind = GOC_ALT_DEFAULT, .ch = NULL },
+        { .op_kind = GOC_ALT_DEFAULT, .ch = NULL }
+    };
+
+    /* Call goc_alts with 2 defaults — must abort() in Phase 1. */
+    goc_alts(ops, 2);
+    /* Unreachable. */
+}
+
+static void p8_4_child_fn(void* arg) {
+    (void)arg;
+
+    /* Spawn a fiber that calls goc_alts with multiple defaults. */
+    goc_go(p8_4_alts_fiber, NULL);
+
+    /* Block the main thread; abort() from the fiber kills the process. */
+    sem_t blocker;
+    sem_init(&blocker, 0, 0);
+    sem_wait(&blocker);
+    /* Unreachable. */
+}
+
+/*
+ * P8.4 — goc_alts() with multiple default arms → abort()
+ *
+ * Verifies that goc_alts() detects and rejects the invariant violation
+ * of having more than one default arm.  Uses fork + waitpid to isolate the
+ * expected crash.
+ */
+static void test_p8_4(void) {
+    TEST_BEGIN("P8.4   goc_alts() with multiple defaults → abort()");
+    bool got_sigabrt = fork_expect_sigabrt(p8_4_child_fn, NULL);
+    ASSERT(got_sigabrt);
+    TEST_PASS();
+done:;
+}
+
+/* --- P8.5: goc_alts_sync() with multiple default arms → abort() --------- */
+
+static void p8_5_child_fn(void* arg) {
+    (void)arg;
+
+    goc_alt_op ops[2] = {
+        { .op_kind = GOC_ALT_DEFAULT, .ch = NULL },
+        { .op_kind = GOC_ALT_DEFAULT, .ch = NULL }
+    };
+
+    /* Call goc_alts_sync with 2 defaults — must abort(). */
+    goc_alts_sync(ops, 2);
+    /* Unreachable. */
+}
+
+/*
+ * P8.5 — goc_alts_sync() with multiple default arms → abort()
+ *
+ * Verifies that goc_alts_sync() detects and rejects the invariant violation
+ * of having more than one default arm.  Uses fork + waitpid to isolate the
+ * expected crash.
+ */
+static void test_p8_5(void) {
+    TEST_BEGIN("P8.5   goc_alts_sync() with multiple defaults → abort()");
+    bool got_sigabrt = fork_expect_sigabrt(p8_5_child_fn, NULL);
+    ASSERT(got_sigabrt);
+    TEST_PASS();
+done:;
+}
+
 /* =========================================================================
  * main
  *
@@ -334,8 +416,10 @@ int main(void) {
     test_p8_1();
     test_p8_2();
     test_p8_3();
-    printf("\n");
+    test_p8_4();
+    test_p8_5();
 
+    printf("\n");
     goc_shutdown();
 
     printf("=========================================================\n");


### PR DESCRIPTION
Enforce single default arm invariant in alts. Fixes #1.

- Reject select ops with more than one GOC_ALT_DEFAULT arm in both goc_alts and goc_alts_sync
- Print diagnostic messages before abort on invariant violations
- Add safety tests:
  - P8.4: goc_alts with multiple defaults (fiber context) aborts
  - P8.5: goc_alts_sync with multiple defaults aborts
- Update design docs to reflect invariant and Phase 8 coverage
- Mark TODO R1 as complete
- Ignore CMake/build and IDE artifacts in .gitignore