### PR TITLE
Implement RW mutexes (issue #13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(GOC_SOURCES
     src/pool.c
     src/fiber.c
     src/channel.c
+    src/mutex.c
     src/minicoro.c
 )
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -57,6 +57,7 @@ libgoc/
 │   ├── pool.c             # Thread pool workers
 │   ├── fiber.c            # minicoro fiber mechanics
 │   ├── channel.c          # Channel operations
+│   ├── mutex.c            # RW mutexes (channel-backed lock handles)
 │   ├── minicoro.c         # Instantiates minicoro (defines MINICORO_IMPL)
 │   ├── internal.h         # Internal types, helpers, and cross-module declarations
 │   ├── chan_type.h         # Authoritative struct goc_chan definition (included by channel.c and alts.c)
@@ -71,6 +72,7 @@ libgoc/
 │   ├── test_p6_thread_pool.c       # Phase 6 — Thread pool
 │   ├── test_p7_integration.c       # Phase 7 — Integration
 │   └── test_p8_safety.c            # Phase 8 — Safety and crash behaviour
+│   └── test_p9_mutexes.c           # Phase 9 — RW mutexes
 ├── vendor/
 │   └── minicoro/
 │       └── minicoro.h     # Vendored header — fiber suspend/resume (header-only)
@@ -96,7 +98,7 @@ The project uses CMake (≥ 3.20). `CMakeLists.txt` defines the following primar
 |---|---|---|
 | `goc` | static library | All `src/*.c` modules; always built |
 | `goc_shared` | shared library | Same sources as `goc`; built only with `-DLIBGOC_SHARED=ON`; output name `libgoc.so` / `.dylib` / `.dll` |
-| `test_p1_foundation` … `test_p8_safety` | executables | One per phase, discovered via `file(GLOB tests/test_p*.c)`; each linked against the active `goc` variant + libuv + Boehm GC |
+| `test_p1_foundation` … `test_p9_mutexes` | executables | One per phase, discovered via `file(GLOB tests/test_p*.c)`; each linked against the active `goc` variant + libuv + Boehm GC |
 
 A CMake function `goc_configure_target(<target>)` centralises the options shared by every library variant: `PUBLIC` include path `include/`, `PRIVATE` paths `src/` and `vendor/minicoro/`, compile definition `GC_THREADS`, and link libraries `PkgConfig::LIBUV` and `PkgConfig::BDWGC`. All library targets (`goc`, `goc_shared`, `goc_asan`, `goc_tsan`) are configured through this function.
 
@@ -987,6 +989,11 @@ void          goc_take_cb(goc_chan* ch,
 void          goc_put_cb(goc_chan* ch, void* val,
                          void (*cb)(goc_status_t ok, void* ud), void* ud);
 
+/* RW mutexes (channel-backed lock handles) */
+goc_mutex*    goc_mutex_make(void);
+goc_chan*     goc_read_lock(goc_mutex* mx);
+goc_chan*     goc_write_lock(goc_mutex* mx);
+
 /* Select */
 goc_alts_result goc_alts     (goc_alt_op* ops, size_t n);
 goc_alts_result goc_alts_sync(goc_alt_op* ops, size_t n);
@@ -1045,10 +1052,11 @@ uv_tcp_init(goc_scheduler(), server);
 `goc_init` must be called exactly once, as the first call in `main()`. Calling it more than once is undefined behaviour. It performs the following steps:
 
 1. **`gc.c`** — Call `GC_INIT()` then `GC_allow_register_threads()` unconditionally. `GC_INIT()` performs all one-time GC setup; `GC_allow_register_threads()` enables multi-thread stack registration and must follow it. This must happen before any `goc_malloc` call.
-2. **`gc.c`** — Initialise the `live_channels` list: a `malloc`-allocated, dynamically grown `goc_chan**` array protected by a plain `pthread_mutex_t`. Must be fully initialised before the loop thread is spawned (step 4) — the loop thread could indirectly trigger `goc_chan_make`, which acquires `g_live_mutex`. `goc_chan_make` is responsible for appending to it; `goc_close` removes entries. Required by `goc_shutdown`.
-3. **`pool.c`** — Initialise the global pool registry (a `malloc`-allocated list protected by a `pthread_mutex_t`). Must be fully initialised before the loop thread is spawned (step 4). Read `GOC_POOL_THREADS` from the environment; default to `max(4, hardware_concurrency)`. Every subsequent `goc_pool_make` call appends to this registry; `goc_pool_destroy` removes the entry. `goc_shutdown` iterates the registry to drain and destroy any pools that remain at teardown time.
-4. **`loop.c`** — Call `loop_init()`. Internally this: allocates and initialises `g_loop`; malloc-allocates and initialises both `uv_async_t` handles (`g_wakeup` via atomic release store, `g_shutdown_async`); calls `cb_queue_init()` to allocate the MPSC sentinel node (must precede thread spawn and requires GC already up); then spawns the dedicated loop thread via plain `pthread_create`. All shared state the loop thread can reach (`g_live_mutex`, pool registry, async handles, callback queue) is fully initialised at this point. Because the loop thread is created with `pthread_create` rather than `GC_pthread_create`, it is outside the GC's automatic registration wrapper — it calls `GC_get_stack_base` and `GC_register_my_thread` at entry and `GC_unregister_my_thread` before exit to ensure its stack is scanned during stop-the-world collection. It runs `while (uv_run(g_loop, UV_RUN_ONCE)) {}` for its entire lifetime.
-5. **`pool.c`** — Call `goc_pool_make(N)` for the default pool, storing the result globally. This spawns the worker threads; done last so workers start only after the full runtime is up.
+2. **`gc.c`** — Initialise the `live_channels` list: a `malloc`-allocated, dynamically grown `goc_chan**` array protected by a plain `pthread_mutex_t`. Must be fully initialised before the loop thread is spawned (step 5) — the loop thread could indirectly trigger `goc_chan_make`, which acquires `g_live_mutex`. `goc_chan_make` is responsible for appending to it; `goc_close` removes entries. Required by `goc_shutdown`.
+3. **`pool.c`** — Initialise the global pool registry (a `malloc`-allocated list protected by a `pthread_mutex_t`). Must be fully initialised before the loop thread is spawned (step 5). Read `GOC_POOL_THREADS` from the environment; default to `max(4, hardware_concurrency)`. Every subsequent `goc_pool_make` call appends to this registry; `goc_pool_destroy` removes the entry. `goc_shutdown` iterates the registry to drain and destroy any pools that remain at teardown time.
+4. **`mutex.c`** — Initialise the global RW-mutex registry (a `malloc`-allocated list protected by a `uv_mutex_t`). `goc_mutex_make` appends to this registry so `goc_shutdown` can destroy the internal `uv_mutex_t` lock for every live `goc_mutex`.
+5. **`loop.c`** — Call `loop_init()`. Internally this: allocates and initialises `g_loop`; malloc-allocates and initialises both `uv_async_t` handles (`g_wakeup` via atomic release store, `g_shutdown_async`); calls `cb_queue_init()` to allocate the MPSC sentinel node (must precede thread spawn and requires GC already up); then spawns the dedicated loop thread via plain `pthread_create`. All shared state the loop thread can reach (`g_live_mutex`, pool registry, async handles, callback queue) is fully initialised at this point. Because the loop thread is created with `pthread_create` rather than `GC_pthread_create`, it is outside the GC's automatic registration wrapper — it calls `GC_get_stack_base` and `GC_register_my_thread` at entry and `GC_unregister_my_thread` before exit to ensure its stack is scanned during stop-the-world collection. It runs `while (uv_run(g_loop, UV_RUN_ONCE)) {}` for its entire lifetime.
+6. **`pool.c`** — Call `goc_pool_make(N)` for the default pool, storing the result globally. This spawns the worker threads; done last so workers start only after the full runtime is up.
 
 ---
 
@@ -1071,9 +1079,9 @@ Once the drain-wait completes, `goc_pool_destroy`:
 
 Because all fibers have returned before `goc_pool_destroy` returns, no code path will ever call `uv_mutex_lock` on a channel lock again. Channel mutexes may therefore be destroyed immediately after this point without deferral.
 
-**Step 2 — Destroy channel mutexes.**
+**Step 2 — Destroy channel and RW-mutex internal locks.**
 
-After `goc_pool_destroy` returns, iterate the `live_channels` list, calling `uv_mutex_destroy` and `free` on each channel's `lock` pointer, then free the list itself.
+After `goc_pool_destroy` returns, iterate the `live_channels` list, calling `uv_mutex_destroy` and `free` on each channel's `lock` pointer, then free the list itself. Then iterate the RW-mutex registry and destroy/free each `goc_mutex` internal lock.
 
 **Step 3 — Signal the loop thread to close both `uv_async_t` handles.**
 
@@ -1225,6 +1233,16 @@ The test suite is split across phase files in `tests/`, each a self-contained C 
 | P8.9 | `goc_take_sync` called from within a fiber → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
 | P8.10 | `goc_put_sync` called from within a fiber → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
 | P8.11 | `goc_alts_sync` called from within a fiber → `abort()`; verified via `fork` + `waitpid` asserting `SIGABRT` |
+
+**Phase 9 — RW mutexes**
+
+| Test | Description |
+|---|---|
+| P9.1 | Read lock acquire+release from an OS thread: `goc_read_lock` returns a lock channel; `goc_take_sync` acquires with `ok==GOC_OK`; `goc_close` releases |
+| P9.2 | Multiple readers can acquire concurrently |
+| P9.3 | Writer blocks while a reader is held, then acquires after reader release |
+| P9.4 | Writer preference: once a writer is queued, subsequent readers queue behind it |
+| P9.5 | Fiber parking path: reader fiber blocks behind writer and resumes after writer release |
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See the [Design Doc](./DESIGN.md) for implementation details and [TODO](./TODO.m
   - [Channel I/O — non-blocking (any context)](#channel-io--non-blocking-any-context)
   - [Channel I/O — fiber context](#channel-io--fiber-context)
   - [Channel I/O — blocking OS threads](#channel-io--blocking-os-threads)
+    - [RW mutexes](#rw-mutexes)
   - [Select (`goc_alts`)](#select-goc_alts)
   - [Timeout channel](#timeout-channel)
   - [Thread pool](#thread-pool)
@@ -461,6 +462,41 @@ Blocks the calling OS thread (not a fiber). Calling these from a fiber is a runt
 goc_val_t result = goc_take_sync(result_ch);
 if (result.ok == GOC_OK)
     process(result.val);
+```
+
+---
+
+### RW mutexes
+
+RW mutexes are channel-backed lock handles:
+
+1. Call `goc_read_lock` or `goc_write_lock` to get a per-acquisition lock channel.
+2. Call `goc_take` / `goc_take_sync` on that channel to wait until the lock is granted.
+3. Call `goc_close` on that lock channel to release the lock.
+
+Readers may hold the lock concurrently. Writers are exclusive. If a writer is queued,
+subsequent readers queue behind it (writer preference) to avoid writer starvation.
+
+| Function | Signature | Description |
+|---|---|---|
+| `goc_mutex_make` | `goc_mutex* goc_mutex_make(void)` | Create a new RW mutex. |
+| `goc_read_lock` | `goc_chan* goc_read_lock(goc_mutex* mx)` | Request a read lock; returns a lock channel to await/close. |
+| `goc_write_lock` | `goc_chan* goc_write_lock(goc_mutex* mx)` | Request a write lock; returns a lock channel to await/close. |
+
+```c
+goc_mutex* mx = goc_mutex_make();
+
+/* Read side */
+goc_chan* r = goc_read_lock(mx);
+goc_take_sync(r);      /* lock acquired */
+/* critical section */
+goc_close(r);          /* release */
+
+/* Write side */
+goc_chan* w = goc_write_lock(mx);
+goc_take_sync(w);      /* lock acquired */
+/* critical section */
+goc_close(w);          /* release */
 ```
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@
   - **R4.2** `goc_put_sync`
   - **R4.3** `goc_alts_sync`
 
-- [ ] **R5** Go-like RW mutexes that park fibers and block threads
+- [x] **R5** Go-like RW mutexes that park fibers and block threads
 
 ### Chores
 

--- a/include/goc.h
+++ b/include/goc.h
@@ -29,6 +29,7 @@ extern "C" {
 
 typedef struct goc_chan goc_chan;
 typedef struct goc_pool goc_pool;
+typedef struct goc_mutex goc_mutex;
 
 /* -------------------------------------------------------------------------
  * Status and value types
@@ -278,6 +279,36 @@ void goc_take_cb(goc_chan* ch,
 void goc_put_cb(goc_chan* ch, void* val,
                 void (*cb)(goc_status_t ok, void* ud),
                 void* ud);
+
+/* -------------------------------------------------------------------------
+ * RW mutexes (channel-backed lock handles)
+ * ---------------------------------------------------------------------- */
+
+/**
+ * goc_mutex_make() — Allocate and return a new RW mutex.
+ *
+ * The mutex itself is GC-heap allocated. Its internal mutex is plain-malloc
+ * allocated (libuv constraint) and is destroyed during goc_shutdown().
+ */
+goc_mutex* goc_mutex_make(void);
+
+/**
+ * goc_read_lock() — Request a read lock and get a lock channel.
+ *
+ * Returns a per-acquisition lock channel. Call goc_take()/goc_take_sync() on
+ * that channel to wait until the lock is acquired (result ok == GOC_OK), then
+ * call goc_close(lock_ch) to release the lock.
+ */
+goc_chan* goc_read_lock(goc_mutex* mx);
+
+/**
+ * goc_write_lock() — Request a write lock and get a lock channel.
+ *
+ * Returns a per-acquisition lock channel. Call goc_take()/goc_take_sync() on
+ * that channel to wait until the lock is acquired (result ok == GOC_OK), then
+ * call goc_close(lock_ch) to release the lock.
+ */
+goc_chan* goc_write_lock(goc_mutex* mx);
 
 /* -------------------------------------------------------------------------
  * Select

--- a/src/chan_type.h
+++ b/src/chan_type.h
@@ -18,6 +18,8 @@ struct goc_chan {
     int          closed;
     size_t       dead_count;
     _Atomic int  close_guard;  /* CAS 0→1 to serialise close; prevents double-close races */
+    void       (*on_close)(void*);
+    void*        on_close_ud;
 };
 
 #endif /* GOC_CHAN_TYPE_H */

--- a/src/channel.c
+++ b/src/channel.c
@@ -129,6 +129,29 @@ goc_chan* goc_chan_make(size_t buf_size)
 }
 
 /* --------------------------------------------------------------------------
+ * chan_set_on_close
+ *
+ * Install or replace an on-close callback for a channel.
+ * If the channel is already closed, invoke the callback immediately.
+ * -------------------------------------------------------------------------- */
+void chan_set_on_close(goc_chan* ch, void (*on_close)(void*), void* ud)
+{
+    int call_now = 0;
+
+    uv_mutex_lock(ch->lock);
+    if (ch->closed) {
+        call_now = 1;
+    } else {
+        ch->on_close = on_close;
+        ch->on_close_ud = ud;
+    }
+    uv_mutex_unlock(ch->lock);
+
+    if (call_now && on_close != NULL)
+        on_close(ud);
+}
+
+/* --------------------------------------------------------------------------
  * goc_close
  *
  * Idempotent. CAS on close_guard ensures exactly one caller proceeds.
@@ -136,6 +159,9 @@ goc_chan* goc_chan_make(size_t buf_size)
  * -------------------------------------------------------------------------- */
 void goc_close(goc_chan* ch)
 {
+    void (*on_close)(void*) = NULL;
+    void* on_close_ud = NULL;
+
     /* Serialise: only one caller wins the CAS 0→1 */
     int expected = 0;
     if (!atomic_compare_exchange_strong_explicit(
@@ -201,8 +227,14 @@ void goc_close(goc_chan* ch)
         }
     }
 
+    on_close = ch->on_close;
+    on_close_ud = ch->on_close_ud;
+
     uv_mutex_unlock(ch->lock);
     chan_unregister(ch);
+
+    if (on_close != NULL)
+        on_close(on_close_ud);
 }
 
 /* --------------------------------------------------------------------------

--- a/src/gc.c
+++ b/src/gc.c
@@ -151,6 +151,9 @@ void goc_init(void) {
     /* Step 4 — Pool registry (pool.c). */
     pool_registry_init();
 
+    /* Step 4.1 — Mutex registry (mutex.c). */
+    mutex_registry_init();
+
     /* Step 5 — libuv event loop + loop thread (loop.c). */
     loop_init();
 
@@ -217,6 +220,9 @@ void goc_shutdown(void) {
     live_channels_cap = 0;
 
     uv_mutex_destroy(&g_live_mutex);
+
+    /* B.2.1 — Destroy all RW mutex internal locks. */
+    mutex_registry_destroy_all();
 
     /* B.3 — Shut down the event loop and join the loop thread. */
     loop_shutdown();

--- a/src/internal.h
+++ b/src/internal.h
@@ -101,6 +101,7 @@ struct goc_entry {
 /* channel.c → used by alts.c, fiber.c */
 void wake(goc_chan* ch, goc_entry* e, void* value);
 void compact_dead_entries(goc_chan* ch);
+void chan_set_on_close(goc_chan* ch, void (*on_close)(void*), void* ud);
 
 /* gc.c → used by channel.c */
 void chan_register(goc_chan* ch);
@@ -118,9 +119,11 @@ void post_callback(goc_entry* entry, void* value);
 /* gc.c → used by pool.c, loop.c */
 void live_channels_init(void);
 void pool_registry_init(void);
+void mutex_registry_init(void);
 
 /* pool.c → used by gc.c */
 void pool_registry_destroy_all(void);
+void mutex_registry_destroy_all(void);
 
 /* ---------------------------------------------------------------------------
  * Inline Ring-Buffer Helpers

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -1,0 +1,285 @@
+/*
+ * src/mutex.c
+ *
+ * Go-like RW mutexes implemented with channel-backed lock handles.
+ *
+ * API contract:
+ *   goc_mutex* mx = goc_mutex_make();
+ *   goc_chan*  lk = goc_read_lock(mx);   // or goc_write_lock(mx)
+ *   goc_take(lk) / goc_take_sync(lk);    // wait until lock is granted
+ *   goc_close(lk);                       // release lock
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdatomic.h>
+#include "../include/goc.h"
+#include "internal.h"
+
+typedef struct goc_mutex_release_ctx goc_mutex_release_ctx;
+
+typedef struct goc_mutex_waiter {
+    struct goc_mutex_waiter* next;
+    goc_chan*                gate;
+    int                      is_writer;
+    goc_mutex_release_ctx*   ctx;
+} goc_mutex_waiter;
+
+struct goc_mutex {
+    uv_mutex_t*       lock;
+    size_t            active_readers;
+    int               writer_active;
+    size_t            waiting_writers;
+    goc_mutex_waiter* q_head;
+    goc_mutex_waiter* q_tail;
+};
+
+struct goc_mutex_release_ctx {
+    goc_mutex* mx;
+    goc_mutex_waiter* waiter;
+    int        is_writer;
+    _Atomic int acquired;
+    _Atomic int handled;
+};
+
+/* ---------------------------------------------------------------------------
+ * Global registry for goc_mutex internal locks
+ * --------------------------------------------------------------------------- */
+
+static goc_mutex** g_live_mutexes     = NULL;
+static size_t      g_live_mutexes_len = 0;
+static size_t      g_live_mutexes_cap = 0;
+static uv_mutex_t  g_live_mutexes_lock;
+
+void mutex_registry_init(void)
+{
+    g_live_mutexes_cap = 32;
+    g_live_mutexes = malloc(g_live_mutexes_cap * sizeof(goc_mutex*));
+    assert(g_live_mutexes != NULL);
+    g_live_mutexes_len = 0;
+    uv_mutex_init(&g_live_mutexes_lock);
+}
+
+static void mutex_register(goc_mutex* mx)
+{
+    uv_mutex_lock(&g_live_mutexes_lock);
+
+    if (g_live_mutexes_len == g_live_mutexes_cap) {
+        size_t new_cap = g_live_mutexes_cap * 2;
+        goc_mutex** grown = realloc(g_live_mutexes, new_cap * sizeof(goc_mutex*));
+        assert(grown != NULL);
+        g_live_mutexes = grown;
+        g_live_mutexes_cap = new_cap;
+    }
+
+    g_live_mutexes[g_live_mutexes_len++] = mx;
+
+    uv_mutex_unlock(&g_live_mutexes_lock);
+}
+
+void mutex_registry_destroy_all(void)
+{
+    for (size_t i = 0; i < g_live_mutexes_len; i++) {
+        goc_mutex* mx = g_live_mutexes[i];
+        uv_mutex_destroy(mx->lock);
+        free(mx->lock);
+    }
+
+    free(g_live_mutexes);
+    g_live_mutexes = NULL;
+    g_live_mutexes_len = 0;
+    g_live_mutexes_cap = 0;
+
+    uv_mutex_destroy(&g_live_mutexes_lock);
+}
+
+/* ---------------------------------------------------------------------------
+ * Helpers
+ * --------------------------------------------------------------------------- */
+
+static void mutex_enqueue(goc_mutex* mx, goc_mutex_waiter* w)
+{
+    w->next = NULL;
+    if (mx->q_tail == NULL) {
+        mx->q_head = w;
+        mx->q_tail = w;
+    } else {
+        mx->q_tail->next = w;
+        mx->q_tail = w;
+    }
+}
+
+static goc_mutex_waiter* mutex_dequeue(goc_mutex* mx)
+{
+    goc_mutex_waiter* w = mx->q_head;
+    if (w == NULL)
+        return NULL;
+
+    mx->q_head = w->next;
+    if (mx->q_head == NULL)
+        mx->q_tail = NULL;
+
+    w->next = NULL;
+    return w;
+}
+
+static void mutex_send_grant(goc_chan* gate)
+{
+    if (goc_in_fiber())
+        (void)goc_put(gate, (void*)1);
+    else
+        (void)goc_put_sync(gate, (void*)1);
+}
+
+static void mutex_release(goc_mutex* mx, int is_writer)
+{
+    goc_mutex_waiter* grant_head = NULL;
+    goc_mutex_waiter* grant_tail = NULL;
+
+    uv_mutex_lock(mx->lock);
+
+    if (is_writer) {
+        mx->writer_active = 0;
+    } else if (mx->active_readers > 0) {
+        mx->active_readers--;
+    }
+
+    if (!mx->writer_active && mx->active_readers == 0 && mx->q_head != NULL) {
+        if (mx->q_head->is_writer) {
+            goc_mutex_waiter* w = mutex_dequeue(mx);
+            mx->waiting_writers--;
+            mx->writer_active = 1;
+            atomic_store_explicit(&w->ctx->acquired, 1, memory_order_release);
+            grant_head = grant_tail = w;
+        } else {
+            while (mx->q_head != NULL && !mx->q_head->is_writer) {
+                goc_mutex_waiter* r = mutex_dequeue(mx);
+                mx->active_readers++;
+                atomic_store_explicit(&r->ctx->acquired, 1, memory_order_release);
+                if (grant_tail == NULL) {
+                    grant_head = grant_tail = r;
+                } else {
+                    grant_tail->next = r;
+                    grant_tail = r;
+                }
+            }
+        }
+    }
+
+    uv_mutex_unlock(mx->lock);
+
+    for (goc_mutex_waiter* it = grant_head; it != NULL; it = it->next)
+        mutex_send_grant(it->gate);
+}
+
+static void mutex_cancel_waiter(goc_mutex* mx, goc_mutex_waiter* target)
+{
+    uv_mutex_lock(mx->lock);
+
+    goc_mutex_waiter* prev = NULL;
+    goc_mutex_waiter* cur = mx->q_head;
+    while (cur != NULL) {
+        if (cur == target) {
+            if (prev == NULL)
+                mx->q_head = cur->next;
+            else
+                prev->next = cur->next;
+
+            if (mx->q_tail == cur)
+                mx->q_tail = prev;
+
+            if (cur->is_writer && mx->waiting_writers > 0)
+                mx->waiting_writers--;
+
+            break;
+        }
+        prev = cur;
+        cur = cur->next;
+    }
+
+    uv_mutex_unlock(mx->lock);
+}
+
+static void mutex_on_lock_channel_closed(void* ud)
+{
+    goc_mutex_release_ctx* ctx = (goc_mutex_release_ctx*)ud;
+    if (atomic_exchange_explicit(&ctx->handled, 1, memory_order_acq_rel))
+        return;
+
+    if (atomic_load_explicit(&ctx->acquired, memory_order_acquire))
+        mutex_release(ctx->mx, ctx->is_writer);
+    else
+        mutex_cancel_waiter(ctx->mx, ctx->waiter);
+}
+
+static goc_chan* mutex_lock_request(goc_mutex* mx, int is_writer)
+{
+    goc_mutex_waiter* w = goc_malloc(sizeof(goc_mutex_waiter));
+    w->gate = goc_chan_make(1);
+    w->is_writer = is_writer;
+    w->next = NULL;
+
+    goc_mutex_release_ctx* ctx = goc_malloc(sizeof(goc_mutex_release_ctx));
+    ctx->mx = mx;
+    ctx->waiter = w;
+    ctx->is_writer = is_writer;
+    atomic_store_explicit(&ctx->acquired, 0, memory_order_release);
+    atomic_store_explicit(&ctx->handled, 0, memory_order_release);
+    w->ctx = ctx;
+    chan_set_on_close(w->gate, mutex_on_lock_channel_closed, ctx);
+
+    int grant_now = 0;
+
+    uv_mutex_lock(mx->lock);
+
+    if (is_writer) {
+        if (!mx->writer_active && mx->active_readers == 0 && mx->q_head == NULL) {
+            mx->writer_active = 1;
+            atomic_store_explicit(&ctx->acquired, 1, memory_order_release);
+            grant_now = 1;
+        } else {
+            mutex_enqueue(mx, w);
+            mx->waiting_writers++;
+        }
+    } else {
+        if (!mx->writer_active && mx->waiting_writers == 0 && mx->q_head == NULL) {
+            mx->active_readers++;
+            atomic_store_explicit(&ctx->acquired, 1, memory_order_release);
+            grant_now = 1;
+        } else {
+            mutex_enqueue(mx, w);
+        }
+    }
+
+    uv_mutex_unlock(mx->lock);
+
+    if (grant_now && !atomic_load_explicit(&ctx->handled, memory_order_acquire))
+        mutex_send_grant(w->gate);
+
+    return w->gate;
+}
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * --------------------------------------------------------------------------- */
+
+goc_mutex* goc_mutex_make(void)
+{
+    goc_mutex* mx = goc_malloc(sizeof(goc_mutex));
+    mx->lock = malloc(sizeof(uv_mutex_t));
+    uv_mutex_init(mx->lock);
+
+    mutex_register(mx);
+    return mx;
+}
+
+goc_chan* goc_read_lock(goc_mutex* mx)
+{
+    return mutex_lock_request(mx, 0);
+}
+
+goc_chan* goc_write_lock(goc_mutex* mx)
+{
+    return mutex_lock_request(mx, 1);
+}

--- a/tests/test_p9_mutexes.c
+++ b/tests/test_p9_mutexes.c
@@ -1,0 +1,264 @@
+/*
+ * tests/test_p9_mutexes.c — Phase 9: RW mutex tests for libgoc
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <time.h>
+#include <semaphore.h>
+#include <pthread.h>
+
+#include "test_harness.h"
+#include "goc.h"
+
+typedef struct { sem_t sem; } done_t;
+
+static void done_init(done_t* d)          { sem_init(&d->sem, 0, 0); }
+static void done_signal(done_t* d)        { sem_post(&d->sem); }
+static void done_wait(done_t* d)          { sem_wait(&d->sem); }
+static void done_destroy(done_t* d)       { sem_destroy(&d->sem); }
+
+static bool done_wait_ms(done_t* d, long ms)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    long nsec = ts.tv_nsec + (ms % 1000) * 1000000L;
+    ts.tv_sec += (ms / 1000) + (nsec / 1000000000L);
+    ts.tv_nsec = nsec % 1000000000L;
+
+    for (;;) {
+        if (sem_timedwait(&d->sem, &ts) == 0)
+            return true;
+        if (errno == EINTR)
+            continue;
+        if (errno == ETIMEDOUT)
+            return false;
+        return false;
+    }
+}
+
+static void test_p9_1(void)
+{
+    TEST_BEGIN("P9.1  read lock acquire+release from OS thread");
+
+    goc_mutex* mx = goc_mutex_make();
+    ASSERT(mx != NULL);
+
+    goc_chan* lk = goc_read_lock(mx);
+    ASSERT(lk != NULL);
+
+    goc_val_t v = goc_take_sync(lk);
+    ASSERT(v.ok == GOC_OK);
+
+    goc_close(lk);
+    TEST_PASS();
+ done:;
+}
+
+static void test_p9_2(void)
+{
+    TEST_BEGIN("P9.2  multiple readers acquire concurrently");
+
+    goc_mutex* mx = goc_mutex_make();
+    ASSERT(mx != NULL);
+
+    goc_chan* r1 = goc_read_lock(mx);
+    goc_chan* r2 = goc_read_lock(mx);
+    ASSERT(r1 != NULL);
+    ASSERT(r2 != NULL);
+
+    goc_val_t v1 = goc_take_sync(r1);
+    goc_val_t v2 = goc_take_sync(r2);
+    ASSERT(v1.ok == GOC_OK);
+    ASSERT(v2.ok == GOC_OK);
+
+    goc_close(r1);
+    goc_close(r2);
+
+    TEST_PASS();
+ done:;
+}
+
+typedef struct {
+    goc_mutex* mx;
+    goc_chan*  lock_ch;
+    goc_val_t  acquired;
+    done_t*    started;
+    done_t*    acquired_sem;
+} writer_thread_args_t;
+
+static void* writer_wait_thread(void* arg)
+{
+    writer_thread_args_t* a = (writer_thread_args_t*)arg;
+    a->lock_ch = goc_write_lock(a->mx);
+    done_signal(a->started);
+    a->acquired = goc_take_sync(a->lock_ch);
+    done_signal(a->acquired_sem);
+    return NULL;
+}
+
+static void test_p9_3(void)
+{
+    TEST_BEGIN("P9.3  writer blocks until reader releases");
+
+    goc_mutex* mx = goc_mutex_make();
+    ASSERT(mx != NULL);
+
+    goc_chan* r = goc_read_lock(mx);
+    ASSERT(r != NULL);
+    ASSERT(goc_take_sync(r).ok == GOC_OK);
+
+    done_t started, acquired;
+    done_init(&started);
+    done_init(&acquired);
+
+    writer_thread_args_t args = {
+        .mx = mx,
+        .started = &started,
+        .acquired_sem = &acquired,
+    };
+
+    pthread_t tid;
+    pthread_create(&tid, NULL, writer_wait_thread, &args);
+
+    done_wait(&started);
+    ASSERT(done_wait_ms(&acquired, 20) == false);
+
+    goc_close(r);
+
+    ASSERT(done_wait_ms(&acquired, 200) == true);
+    ASSERT(args.acquired.ok == GOC_OK);
+
+    goc_close(args.lock_ch);
+
+    pthread_join(tid, NULL);
+    done_destroy(&started);
+    done_destroy(&acquired);
+
+    TEST_PASS();
+ done:;
+}
+
+static void test_p9_4(void)
+{
+    TEST_BEGIN("P9.4  queued writer blocks subsequent readers");
+
+    goc_mutex* mx = goc_mutex_make();
+    ASSERT(mx != NULL);
+
+    goc_chan* r1 = goc_read_lock(mx);
+    ASSERT(r1 != NULL);
+    ASSERT(goc_take_sync(r1).ok == GOC_OK);
+
+    goc_chan* w1 = goc_write_lock(mx);
+    ASSERT(w1 != NULL);
+
+    goc_chan* r2 = goc_read_lock(mx);
+    ASSERT(r2 != NULL);
+
+    goc_val_t try_r2_before = goc_take_try(r2);
+    ASSERT(try_r2_before.ok == GOC_EMPTY);
+
+    goc_close(r1);
+
+    goc_val_t wv = goc_take_sync(w1);
+    ASSERT(wv.ok == GOC_OK);
+
+    goc_val_t try_r2_during = goc_take_try(r2);
+    ASSERT(try_r2_during.ok == GOC_EMPTY);
+
+    goc_close(w1);
+
+    goc_val_t r2v = goc_take_sync(r2);
+    ASSERT(r2v.ok == GOC_OK);
+
+    goc_close(r2);
+
+    TEST_PASS();
+ done:;
+}
+
+typedef struct {
+    goc_mutex* mx;
+    goc_status_t ok;
+    done_t* done;
+} fiber_wait_reader_args_t;
+
+static void fiber_wait_reader(void* arg)
+{
+    fiber_wait_reader_args_t* a = (fiber_wait_reader_args_t*)arg;
+    goc_chan* r = goc_read_lock(a->mx);
+    goc_val_t v = goc_take(r);
+    a->ok = v.ok;
+    done_signal(a->done);
+    goc_close(r);
+}
+
+static void test_p9_5(void)
+{
+    TEST_BEGIN("P9.5  fiber parks on read lock behind writer");
+
+    goc_mutex* mx = goc_mutex_make();
+    ASSERT(mx != NULL);
+
+    goc_chan* w = goc_write_lock(mx);
+    ASSERT(w != NULL);
+    ASSERT(goc_take_sync(w).ok == GOC_OK);
+
+    done_t done;
+    done_init(&done);
+
+    fiber_wait_reader_args_t args = {
+        .mx = mx,
+        .ok = GOC_EMPTY,
+        .done = &done,
+    };
+
+    goc_chan* join = goc_go(fiber_wait_reader, &args);
+    ASSERT(join != NULL);
+
+    ASSERT(done_wait_ms(&done, 20) == false);
+
+    goc_close(w);
+
+    ASSERT(done_wait_ms(&done, 200) == true);
+    ASSERT(args.ok == GOC_OK);
+
+    goc_val_t jv = goc_take_sync(join);
+    ASSERT(jv.ok == GOC_CLOSED);
+
+    done_destroy(&done);
+    TEST_PASS();
+ done:;
+}
+
+int main(void)
+{
+    install_crash_handler();
+
+    printf("libgoc test suite — Phase 9: RW mutexes\n");
+    printf("=========================================\n\n");
+
+    goc_init();
+
+    printf("Phase 9 — RW mutexes\n");
+    test_p9_1();
+    test_p9_2();
+    test_p9_3();
+    test_p9_4();
+    test_p9_5();
+    printf("\n");
+
+    goc_shutdown();
+
+    printf("=========================================\n");
+    printf("Results: %d/%d passed", g_tests_passed, g_tests_run);
+    if (g_tests_failed > 0)
+        printf(", %d FAILED", g_tests_failed);
+    printf("\n");
+
+    return (g_tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
Add reader/writer mutexes where lock acquisition and release are expressed as channel operations:

  mx = goc_mutex_make() lk = goc_read_lock(mx)   // or goc_write_lock(mx) goc_take(lk)             // park fiber until granted goc_close(lk)            // release

## Implementation:
- src/mutex.c: RW mutex internals — FIFO waiter queue, concurrent reader grant, exclusive writer grant, writer-preference queueing to prevent starvation
- src/chan_type.h: add on_close/on_close_ud hook fields to goc_chan
- src/channel.c: invoke on_close hook after close; add chan_set_on_close() setter (immediate call if already closed)
- src/internal.h: declare chan_set_on_close, mutex_registry_init, mutex_registry_destroy_all
- src/gc.c: call mutex_registry_init() during goc_init and mutex_registry_destroy_all() during goc_shutdown
- include/goc.h: expose goc_mutex opaque type + three public functions (goc_mutex_make, goc_read_lock, goc_write_lock)
- CMakeLists.txt: add src/mutex.c to GOC_SOURCES

## Tests (tests/test_p9_mutexes.c): 
- P9.1  read lock acquire+release from OS thread 
- P9.2  multiple readers acquire concurrently 
- P9.3  writer blocks until reader releases 
- P9.4  writer preference — queued writer blocks subsequent readers 
- P9.5  fiber parks on read lock behind active writer, resumes on release