### PR TITLE
Telemetry: Add pool_id to worker stats

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -52,11 +52,12 @@
 | `GOC_POOL_DESTROYED`    | `1`   | Pool torn down   |
 
 ### Worker Events (`GOC_STATS_EVENT_WORKER_STATUS`)
-| Field          | Type  | Description                    |
-|----------------|-------|--------------------------------|
-| `id`           | `int` | Worker index                   |
-| `status`       | `int` | See `goc_stats_worker_status`  |
-| `pending_jobs` | `int` | Live fiber count in the pool   |
+| Field          | Type    | Description                    |
+|----------------|---------|--------------------------------|
+| `id`           | `int`   | Worker index                   |
+| `pool_id`      | `void*` | Pool pointer                   |
+| `status`       | `int`   | See `goc_stats_worker_status`  |
+| `pending_jobs` | `int`   | Live fiber count in the pool   |
 
 | `goc_stats_worker_status` | Value | Meaning                       |
 |---------------------------|-------|-------------------------------|
@@ -118,7 +119,7 @@ struct goc_stats_event {
 	uint64_t timestamp;
 	union {
 		struct { int id; int status; int thread_count; } pool;
-		struct { int id; int status; int pending_jobs; } worker;
+		struct { int id; void* pool_id; int status; int pending_jobs; } worker;
 		struct { int id; int last_worker_id; int status; } fiber;
 		struct { int id; int status; int buf_size; int item_count; } channel;
 	} data;
@@ -133,15 +134,15 @@ Macros emit events if telemetry is enabled, or become no-ops otherwise:
 #ifdef GOC_ENABLE_STATS
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count) \
 	goc_stats_submit_event_pool((id), (status), (thread_count))
-#  define GOC_STATS_WORKER_STATUS(id, status, pending_jobs) \
-	goc_stats_submit_event_worker((id), (status), (pending_jobs))
+#  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs) \
+	goc_stats_submit_event_worker((id), (pool_id), (status), (pending_jobs))
 #  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status) \
 	goc_stats_submit_event_fiber((id), (last_worker_id), (status))
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count) \
 	goc_stats_submit_event_channel((id), (status), (buf_size), (item_count))
 #else
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count)            ((void)0)
-#  define GOC_STATS_WORKER_STATUS(id, status, pending_jobs)          ((void)0)
+#  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs) ((void)0)
 #  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status)         ((void)0)
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count) ((void)0)
 #endif
@@ -165,16 +166,16 @@ Macros emit events if telemetry is enabled, or become no-ops otherwise:
 After `goc_stats_init()`, all events are printed to stdout by the built-in default callback. For a program that creates a pool, spawns a fiber, and shuts down, the output looks like:
 
 ```
-[goc_stats] WORKER @ 1748000000000000000: id=0 status=0 pending=0
-[goc_stats] WORKER @ 1748000000001000000: id=1 status=0 pending=0
+[goc_stats] WORKER @ 1748000000000000000: id=0 pool=0x55a1b2c3d000 status=0 pending=0
+[goc_stats] WORKER @ 1748000000001000000: id=1 pool=0x55a1b2c3d000 status=0 pending=0
 [goc_stats] POOL @ 1748000000002000000: pool=0x55a1b2c3d000 status=0 threads=2
 [goc_stats] FIBER @ 1748000000003000000: id=0 last_worker=-1 status=0
-[goc_stats] WORKER @ 1748000000004000000: id=0 status=1 pending=1
+[goc_stats] WORKER @ 1748000000004000000: id=0 pool=0x55a1b2c3d000 status=1 pending=1
 [goc_stats] FIBER @ 1748000000005000000: id=0 last_worker=0 status=1
-[goc_stats] WORKER @ 1748000000006000000: id=0 status=2 pending=0
+[goc_stats] WORKER @ 1748000000006000000: id=0 pool=0x55a1b2c3d000 status=2 pending=0
 [goc_stats] POOL @ 1748000000007000000: pool=0x55a1b2c3d000 status=1 threads=2
-[goc_stats] WORKER @ 1748000000008000000: id=0 status=3 pending=0
-[goc_stats] WORKER @ 1748000000009000000: id=1 status=3 pending=0
+[goc_stats] WORKER @ 1748000000008000000: id=0 pool=0x55a1b2c3d000 status=3 pending=0
+[goc_stats] WORKER @ 1748000000009000000: id=1 pool=0x55a1b2c3d000 status=3 pending=0
 ```
 
 See the [Event Types](#event-types) tables for status enum values.
@@ -205,7 +206,7 @@ int main(void) {
 ```c
 GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_CREATED, thread_count); // pool created
 GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_DESTROYED, thread_count); // pool destroyed
-GOC_STATS_WORKER_STATUS(worker_id, GOC_WORKER_RUNNING, pending_jobs);
+GOC_STATS_WORKER_STATUS(worker_id, pool, GOC_WORKER_RUNNING, pending_jobs);
 GOC_STATS_FIBER_STATUS(fiber_id, last_worker_id, GOC_FIBER_CREATED);
 GOC_STATS_CHANNEL_STATUS(goc_box_int(ch), 1, ch->buf_size, 0); // channel open
 GOC_STATS_CHANNEL_STATUS(goc_box_int(ch), 0, ch->buf_size, 0); // channel close

--- a/include/goc_stats.h
+++ b/include/goc_stats.h
@@ -58,7 +58,7 @@ struct goc_stats_event {
     uint64_t timestamp;
     union {
         struct { void* id; int status; int thread_count; } pool;
-        struct { int id; int status; int pending_jobs; } worker;
+        struct { int id; void* pool_id; int status; int pending_jobs; } worker;
         struct { int id; int last_worker_id; int status; } fiber;
         struct { int id; int status; int buf_size; int item_count; } channel;
     } data;
@@ -93,7 +93,7 @@ bool goc_stats_is_enabled(void);
 
 #ifdef GOC_ENABLE_STATS
 void goc_stats_submit_event_pool(void* id, int status, int thread_count);
-void goc_stats_submit_event_worker(int id, int status, int pending_jobs);
+void goc_stats_submit_event_worker(int id, void* pool_id, int status, int pending_jobs);
 void goc_stats_submit_event_fiber(int id, int last_worker_id, int status);
 void goc_stats_submit_event_channel(int id, int status, int buf_size, int item_count);
 #endif
@@ -105,15 +105,15 @@ void goc_stats_submit_event_channel(int id, int status, int buf_size, int item_c
 #ifdef GOC_ENABLE_STATS
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count) \
     goc_stats_submit_event_pool((id), (status), (thread_count))
-#  define GOC_STATS_WORKER_STATUS(id, status, pending_jobs) \
-    goc_stats_submit_event_worker((id), (status), (pending_jobs))
+#  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs) \
+    goc_stats_submit_event_worker((id), (pool_id), (status), (pending_jobs))
 #  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status) \
     goc_stats_submit_event_fiber((id), (last_worker_id), (status))
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count) \
     goc_stats_submit_event_channel((id), (status), (buf_size), (item_count))
 #else
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count)            ((void)0)
-#  define GOC_STATS_WORKER_STATUS(id, status, pending_jobs)          ((void)0)
+#  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs) ((void)0)
 #  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status)         ((void)0)
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count) ((void)0)
 #endif

--- a/src/goc_stats.c
+++ b/src/goc_stats.c
@@ -139,8 +139,9 @@ static void goc_stats_default_callback(const struct goc_stats_event *ev, void *u
                    ev->data.pool.id, ev->data.pool.status, ev->data.pool.thread_count);
             break;
         case GOC_STATS_EVENT_WORKER_STATUS:
-            printf("id=%d status=%d pending=%d\n",
-                   ev->data.worker.id, ev->data.worker.status, ev->data.worker.pending_jobs);
+            printf("id=%d pool=%p status=%d pending=%d\n",
+                   ev->data.worker.id, ev->data.worker.pool_id,
+                   ev->data.worker.status, ev->data.worker.pending_jobs);
             break;
         case GOC_STATS_EVENT_FIBER_STATUS:
             printf("id=%d last_worker=%d status=%d\n",
@@ -246,11 +247,12 @@ void goc_stats_submit_event_pool(void *id, int status, int thread_count) {
     goc_stats_dispatch(&ev);
 }
 
-void goc_stats_submit_event_worker(int id, int status, int pending_jobs) {
+void goc_stats_submit_event_worker(int id, void *pool_id, int status, int pending_jobs) {
     struct goc_stats_event ev;
     ev.type                     = GOC_STATS_EVENT_WORKER_STATUS;
     ev.timestamp                = goc_stats_now();
     ev.data.worker.id           = id;
+    ev.data.worker.pool_id      = pool_id;
     ev.data.worker.status       = status;
     ev.data.worker.pending_jobs = pending_jobs;
     goc_stats_dispatch(&ev);

--- a/src/pool.c
+++ b/src/pool.c
@@ -264,7 +264,7 @@ void pool_submit_spawn(goc_pool* pool,
         GOC_STATS_WORKER_STATUS(
             (int)atomic_load_explicit(&pool->next_push_idx, memory_order_relaxed)
                  % (int)pool->thread_count,
-            GOC_WORKER_RUNNING, (int)live);
+            pool, GOC_WORKER_RUNNING, (int)live);
         post_to_run_queue(pool, entry);
         return;
     }
@@ -343,10 +343,10 @@ static void pool_worker_fn(void* arg) {
             goto run;
         }
 
-        GOC_STATS_WORKER_STATUS((int)tl_worker->index, GOC_WORKER_IDLE, (int)pool->live_count);
+        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_IDLE, (int)pool->live_count);
         uv_sem_wait(&tl_worker->idle_sem);
         atomic_fetch_sub_explicit(&pool->idle_count, 1, memory_order_relaxed);
-        GOC_STATS_WORKER_STATUS((int)tl_worker->index, GOC_WORKER_RUNNING, (int)pool->live_count);
+        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_RUNNING, (int)pool->live_count);
         continue;   /* re-check shutdown and try again */
 
 run:
@@ -400,12 +400,12 @@ run:
             uv_cond_broadcast(&pool->drain_cond);
             uv_mutex_unlock(&pool->drain_mutex);
 
-            GOC_STATS_WORKER_STATUS((int)tl_worker->index, GOC_WORKER_RUNNING, (int)pool->live_count);
+            GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_RUNNING, (int)pool->live_count);
             pool_dispatch_spawn_list(pool, admitted);
         }
     }
 
-    GOC_STATS_WORKER_STATUS((int)tl_worker->index, GOC_WORKER_STOPPED, 0);
+    GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_STOPPED, 0);
     tl_worker = NULL;
 }
 
@@ -517,7 +517,7 @@ goc_pool* goc_pool_make(size_t threads) {
                     i + 1, threads, rc);
             abort();
         }
-        GOC_STATS_WORKER_STATUS((int)i, GOC_WORKER_CREATED, 0);
+        GOC_STATS_WORKER_STATUS((int)i, pool, GOC_WORKER_CREATED, 0);
     }
 
     GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_CREATED, (int)threads);

--- a/tests/test_goc_stats.c
+++ b/tests/test_goc_stats.c
@@ -183,7 +183,7 @@ static const struct goc_stats_event* find_any_worker_status(
 
 static void emit_worker_event(void* arg) {
     (void)arg;
-    GOC_STATS_WORKER_STATUS(/*id=*/42, GOC_WORKER_RUNNING, /*pending_jobs=*/5);
+    GOC_STATS_WORKER_STATUS(/*id=*/42, /*pool_id=*/NULL, GOC_WORKER_RUNNING, /*pending_jobs=*/5);
 }
 
 static void emit_fiber_event(void* arg) {
@@ -230,6 +230,7 @@ static void test_s1_3(void) {
     ASSERT(ev->type == GOC_STATS_EVENT_WORKER_STATUS);
     ASSERT(ev->timestamp > 0);
     ASSERT(ev->data.worker.id           == 42);
+    ASSERT(ev->data.worker.pool_id      == NULL);
     ASSERT(ev->data.worker.status       == GOC_WORKER_RUNNING);
     ASSERT(ev->data.worker.pending_jobs == 5);
     TEST_PASS();


### PR DESCRIPTION
Add `pool_id` (`void*`) to worker telemetry events.

**Changed files:**
- `include/goc_stats.h` — added `pool_id` field to the `worker` data struct; updated `goc_stats_submit_event_worker` signature; updated `GOC_STATS_WORKER_STATUS` macro (both enabled and no-op variants)
- `src/goc_stats.c` — updated `goc_stats_submit_event_worker` implementation to populate `pool_id`; updated default stdout callback to print `pool=%p`
- `src/pool.c` — all five `GOC_STATS_WORKER_STATUS` call sites now pass the `pool` pointer as `pool_id`
- `tests/test_goc_stats.c` — updated call site; added assertion on `pool_id`
- `TELEMETRY.md` — updated event table, struct snippet, macros, example output, and emission example