### PR TITLE
Fix flaky tests S4.1, S6.2, P7.5

### DIFF
--- a/tests/test_goc_stats.c
+++ b/tests/test_goc_stats.c
@@ -740,6 +740,7 @@ static void test_s6_2(void) {
     uint64_t allocs0, expires0;
     goc_timeout_get_stats(&allocs0, &expires0);
 
+    goc_stats_flush();
     goc_chan* chs[S6_2_N];
     for (int i = 0; i < S6_2_N; i++)
         chs[i] = goc_timeout(20); /* 20 ms */
@@ -803,6 +804,7 @@ done:;
 static void test_s4_1(void) {
     TEST_BEGIN("S4_1  goc_stats_shutdown disables stats");
     ASSERT(goc_stats_is_enabled());
+    goc_stats_flush();
     goc_stats_shutdown();
     ASSERT(!goc_stats_is_enabled());
     TEST_PASS();

--- a/tests/test_p05_select_timeout.c
+++ b/tests/test_p05_select_timeout.c
@@ -1108,6 +1108,7 @@ done:;
 
 int main(void) {
     install_crash_handler();
+    goc_test_arm_watchdog(30);
 
     printf("libgoc test suite — Phase 5: Select and timeout\n");
     printf("=================================================\n\n");

--- a/tests/test_p07_integration.c
+++ b/tests/test_p07_integration.c
@@ -59,6 +59,7 @@
 
 #include "test_harness.h"
 #include "goc.h"
+#include "goc_stats.h"
 
 /* =========================================================================
  * done_t — lightweight fiber-to-main synchronisation via mutex + condvar
@@ -605,6 +606,7 @@ static void test_p7_5(void) {
     goc_take_sync(fast_blocked_ch);
     goc_close(fast_blocked_ch);
 
+    goc_stats_flush();
     goc_chan* tch = goc_timeout(P7_5_TIMEOUT_MS);
     ASSERT(tch != NULL);
 
@@ -652,6 +654,7 @@ done:;
 
 int main(void) {
     install_crash_handler();
+    goc_test_arm_watchdog(30);
 
     printf("libgoc test suite — Phase 7: Integration\n");
     printf("=========================================\n\n");


### PR DESCRIPTION
Fixes #67 

All three tests timed out intermittently under load. The root cause is shared: the stats subsystem emits events on the same libuv event loop that drives goc_timeout timers.

When preceding tests saturate the loop with stats events, timer callbacks are delayed — causing goc_take_sync on timeout channels (S6.2, P7.5) and uv_close on the stats async handle (S4.1) to hang until the watchdog fires.

Fix: call goc_stats_flush() before any timing-sensitive operation in each affected test. flush() blocks until the loop has drained all pending stats events, ensuring the loop is uncontested when the timeout channels and shutdown close callback need to be processed.

- S4.1: flush before goc_stats_shutdown() (loop backlogged by all preceding stats tests)
- S6.2: flush before creating the goc_timeout(20) channels (loop backlogged by S6.1's callback-queue burst)
- P7.5: flush before goc_timeout(80) / goc_alts_sync (loop backlogged by stats instrumentation on earlier P7 tests)