### PR TITLE
Fix flaky test P6.23: dangling pointer to wave-local stack variables

### DIFF
--- a/tests/test_p06_thread_pool.c
+++ b/tests/test_p06_thread_pool.c
@@ -1798,9 +1798,11 @@ static void test_p6_23(void) {
     goc_pool* pool = goc_pool_make(P6_23_WORKERS);
     ASSERT(pool != NULL);
 
+    _Atomic int completed = 0;
+    p6_23_arg_t args = { &done, &completed, P6_23_PER_WAVE };
+
     for (int w = 0; w < P6_23_WAVES; w++) {
-        _Atomic int completed = 0;
-        p6_23_arg_t args = { &done, &completed, P6_23_PER_WAVE };
+        atomic_store_explicit(&completed, 0, memory_order_relaxed);
 
         for (int i = 0; i < P6_23_PER_WAVE; i++)
             goc_go_on(pool, p6_23_fiber_fn, &args);


### PR DESCRIPTION
P6.23 spawns N_WAVES waves of fibers and waits for each wave to finish before starting the next.  completed and args were declared inside the wave loop body, so each iteration created new stack variables and passed their addresses to the spawned fibers.

done_wait_timeout returns as soon as the last fiber calls done_signal. done_signal holds the mutex through uv_cond_signal + uv_mutex_unlock, so by the time the main thread exits done_wait_timeout the signalling fiber has released the mutex and will not access args again.  However, the fiber has not yet fully unwound from the worker — it is still returning from p6_23_fiber_fn.  

At that moment the loop body ends, completed and args go out of scope, and the next iteration re-creates them at the same stack addresses.  Any fiber still in flight from the previous wave holds a now-dangling p6_23_arg_t* — a use-after-scope UB that can corrupt the next wave's completed count or trigger a spurious done_signal.

Fix: move completed and args outside the wave loop so their lifetime spans all waves.  Reset completed with atomic_store_explicit at the top of each iteration.  This is safe because done_wait_timeout only returns after all N fibers have executed their atomic_fetch_add and the last one has fully released the mutex, so no wave-W fiber will ever touch completed again before the store for wave W+1.