### PR TITLE
HTTP: keep-alive, server shutdown drain, new pool-context APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ bench/libgoc/bench-vmem-old
 fix.md
 meta/*
 test.log
+
+# Clojure cache files
+bench/clojure/.cpcache/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -472,7 +472,7 @@ goc_chan* goc_go(void (*fn)(void*), void* arg);
 goc_chan* goc_go_on(goc_pool*, void (*fn)(void*), void* arg);
 ```
 
-`goc_go` posts to the default pool. `goc_go_on` posts to a specific pool. Both return a join channel — see [Join Channel](#join-channel) below. Multiple pools allow priority separation or affinity pinning.
+`goc_go` posts to the current pool when called from a fiber, and falls back to the default pool outside fiber context. `goc_go_on` posts to a specific pool. Both return a join channel — see [Join Channel](#join-channel) below. Multiple pools allow priority separation or affinity pinning.
 
 ### Launch (`goc_go`)
 

--- a/HTTP.md
+++ b/HTTP.md
@@ -40,7 +40,7 @@ Two HTTP servers bounce a counter back and forth over HTTP.
   and POSTs back to server A.
 - `main_fiber` sets up both servers, fires the first request, then waits on a
   done-channel that server A closes when finished.
-- Both servers share the default pool.
+- Both servers share the default thread pool.
 
 ```c
 #include <stdio.h>
@@ -68,6 +68,7 @@ static void handler_a(goc_http_ctx_t* ctx) {
 
     char* msg = goc_sprintf("%d", n + 1);
     goc_http_request_opts_t* fwd_opts = goc_http_request_opts();
+    fwd_opts->keep_alive = 1;
     goc_http_post(ADDR_B, "text/plain", msg, fwd_opts);
 }
 
@@ -79,6 +80,7 @@ static void handler_b(goc_http_ctx_t* ctx) {
 
     char* msg = goc_sprintf("%d", n + 1);
     goc_http_request_opts_t* fwd_opts = goc_http_request_opts();
+    fwd_opts->keep_alive = 1;
     goc_http_post(ADDR_A, "text/plain", msg, fwd_opts);
 }
 
@@ -100,6 +102,7 @@ static void main_fiber(void* _) {
     goc_take(ready_b);
 
     goc_http_request_opts_t* start_opts = goc_http_request_opts();
+    start_opts->keep_alive = 1;
     goc_http_post(ADDR_A, "text/plain", "0", start_opts);
 
     goc_take(done);
@@ -139,7 +142,8 @@ what `goc_io` already uses.
 
 **Client**: outbound requests return a channel that delivers a
 `goc_http_response_t*` when the response arrives. A single `http_client_fiber`
-on the default pool drives the entire request: DNS lookup via
+on `opts->pool` (or `goc_current_or_default_pool()` when unset) drives the
+entire request: DNS lookup via
 `goc_io_getaddrinfo`, TCP connect via `goc_io_tcp_connect`, write via
 `goc_io_write`, and read/parse via `goc_io_read_start`. All I/O completes
 through `goc_take` in the fiber. The event loop is never blocked; other fibers
@@ -176,7 +180,7 @@ through `goc_http_ctx_t` helpers; the context is valid only until
 Server-side functions (`goc_http_server_respond`, `goc_http_server_header`, etc.) operate
 within the per-connection fiber and do not need any cross-thread dispatch.
 Client-side functions (`goc_http_get`, `goc_http_post`, etc.) launch a fiber
-on the default pool that drives the entire request through `goc_io` channel
+on `opts->pool` (or the current-or-default pool when unset) that drives the entire request through `goc_io` channel
 operations and are safe to call from any fiber.
 
 `goc_http_ctx_t` must not be passed across independent requests or stored
@@ -244,7 +248,7 @@ typedef goc_http_status_t (*goc_http_middleware_t)(goc_http_ctx_t* ctx);
  */
 typedef struct {
     /* Pool whose libuv loop the server runs on.
-     * Default (NULL): goc_default_pool(). */
+    * Default (NULL): goc_current_or_default_pool(). */
     goc_pool* pool;
 
     /* Middleware chain executed in order inside the per-request fiber before
@@ -265,12 +269,21 @@ typedef struct {
 /* goc_http_request_opts_t — options for outbound requests.
  * Obtain a heap-allocated zero-initialised default with goc_http_request_opts(). */
 typedef struct {
+    /* Pool to run the outbound client fiber on.
+     * Default (NULL): goc_current_or_default_pool(). */
+    goc_pool* pool;
+
     /* Extra headers to send with the request.
      * goc_array of goc_http_header_t*.  Default (NULL): none. */
     goc_array* headers;
 
     /* Request timeout in milliseconds.  0 = no timeout. */
     uint64_t timeout_ms;
+
+    /* Enable HTTP/1.1 keep-alive and connection reuse.
+     * 0 = disabled (default), non-zero = enabled.
+     */
+    int keep_alive;
 } goc_http_request_opts_t;
 ```
 
@@ -280,7 +293,7 @@ typedef struct {
 
 | Function | Signature | Description |
 |---|---|---|
-| `goc_http_server_opts` | `goc_http_server_opts_t* goc_http_server_opts(void)` | Allocate and return a default options struct. All fields zero-initialised: `pool` defaults to `goc_default_pool()`, `middleware` to NULL. |
+| `goc_http_server_opts` | `goc_http_server_opts_t* goc_http_server_opts(void)` | Allocate and return a default options struct. `pool` defaults to `goc_current_or_default_pool()`, `middleware` to NULL. |
 | `goc_http_server_make` | `goc_http_server_t* goc_http_server_make(const goc_http_server_opts_t* opts)` | Allocate and initialise a server from `opts`. Returns a GC-managed pointer. Never returns NULL (aborts on failure). |
 | `goc_http_server_listen` | `goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int port)` | Bind and start listening on `host:port`. Returns a channel that delivers `goc_box_int(rc)` once `uv_listen` has been called on the event-loop thread (rc == 0 = ready; rc < 0 = libuv error). Always `goc_take()` the channel before sending requests. |
 | `goc_http_server_close` | `goc_chan* goc_http_server_close(goc_http_server_t* srv)` | Gracefully stop accepting new connections and drain in-flight requests. Returns a channel delivering `goc_box_int(0)` when shutdown is complete. Safe from any context. |
@@ -404,8 +417,10 @@ All client functions return a channel that delivers a `goc_http_response_t*`
 when the response arrives. `goc_take` the channel to receive the result.
 Must be called from fiber context.
 
-`goc_http_request_opts_t` carries optional headers and a timeout. Pass
-`goc_http_request_opts()` for defaults (no extra headers, no timeout).
+`goc_http_request_opts_t` carries optional pool override, headers, timeout,
+and a keep-alive toggle. Pass `goc_http_request_opts()` for defaults (pool
+defaults to `goc_current_or_default_pool()`, no extra headers, no timeout,
+keep-alive disabled).
 
 Because the functions return channels, multiple requests can be issued in
 parallel and awaited with `goc_alts` or `goc_take_all`:
@@ -425,7 +440,7 @@ goc_http_response_t* r2 = goc_take(c2)->val;
 
 | Function | Signature | Description |
 |---|---|---|
-| `goc_http_request_opts` | `goc_http_request_opts_t* goc_http_request_opts(void)` | Allocate and return a default request options struct. Zero-initialised: no headers, no timeout. |
+| `goc_http_request_opts` | `goc_http_request_opts_t* goc_http_request_opts(void)` | Allocate and return a default request options struct. Pool defaults to `goc_current_or_default_pool()`, no headers, no timeout, keep-alive disabled. |
 
 ### REST helpers
 
@@ -460,6 +475,7 @@ h->name  = "Authorization";
 h->value = "Bearer my-token";
 opts->headers    = goc_array_of(h);
 opts->timeout_ms = 5000;
+opts->keep_alive = 1;
 
 goc_chan* post_ch = goc_http_post("http://api.example.com/items",
                                    "application/json",

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ int main(void) {
 
 - `goc_chan_make(0)` — unbuffered channels enforce a synchronous rendezvous:
   each `goc_put` blocks until the other fiber calls `goc_take`, and vice versa.
-- `goc_go` — spawns both player fibers on the default pool and returns a join
+- `goc_go` — spawns both player fibers on the current pool (or default pool
+    when called outside fiber context) and returns a join
   channel that is closed automatically when the fiber returns.
 - `goc_close` — when the round limit is reached the active fiber closes the
   forward channel, causing the partner's next `goc_take` to return
@@ -398,6 +399,10 @@ goc_close(ch);
 | Function | Signature | Description |
 |---|---|---|
 | `goc_in_fiber` | `bool goc_in_fiber(void)` | Returns `true` if the caller is executing inside a fiber, `false` otherwise. Safe to call from any context after `goc_init` returns. |
+| `goc_current_pool` | `goc_pool* goc_current_pool(void)` | Return the current fiber's pool, or `NULL` when called outside fiber context. |
+| `goc_current_or_default_pool` | `goc_pool* goc_current_or_default_pool(void)` | Return current pool when in fiber context, otherwise return the default pool. |
+| `goc_current_thread` | `uv_thread_t goc_current_thread(void)` | Return the current OS thread id (libuv thread type). |
+| `goc_current_fiber` | `void* goc_current_fiber(void)` | Return the current runtime fiber handle, or `NULL` outside fiber context. |
 
 ---
 
@@ -405,7 +410,7 @@ goc_close(ch);
 
 | Function | Signature | Description |
 |---|---|---|
-| `goc_go` | `goc_chan* goc_go(void (*fn)(void*), void* arg)` | Spawn a fiber on the default pool. Returns a **join channel** that is closed automatically when the fiber returns. Pass the join channel as an arm to `goc_alts` or call `goc_take`/`goc_take_sync` on it to await fiber completion. The join channel may be ignored if no join is needed. |
+| `goc_go` | `goc_chan* goc_go(void (*fn)(void*), void* arg)` | Spawn a fiber on the current pool when called from a fiber; otherwise on the default pool. Returns a **join channel** that is closed automatically when the fiber returns. Pass the join channel as an arm to `goc_alts` or call `goc_take`/`goc_take_sync` on it to await fiber completion. The join channel may be ignored if no join is needed. |
 | `goc_go_on` | `goc_chan* goc_go_on(goc_pool* pool, void (*fn)(void*), void* arg)` | Spawn on a specific pool. Returns a join channel with the same semantics as `goc_go`. |
 
 ```c

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -43,7 +43,7 @@
 ### Pool Events (`GOC_STATS_EVENT_POOL_STATUS`)
 | Field          | Type    | Description                   |
 |----------------|---------|-------------------------------|
-| `id`           | `void*` | Pool pointer                  |
+| `id`           | `int`   | Monotonic pool ID             |
 | `status`       | `int`   | See `goc_stats_pool_status_t`   |
 | `thread_count` | `int`   | Number of worker threads      |
 
@@ -56,7 +56,7 @@
 | Field              | Type       | Description                                                        |
 |--------------------|------------|--------------------------------------------------------------------|
 | `id`               | `int`      | Worker index                                                       |
-| `pool_id`          | `void*`    | Pool pointer                                                       |
+| `pool_id`          | `int`      | Owning pool ID                                                     |
 | `status`           | `int`      | See `goc_stats_worker_status_t`                                      |
 | `pending_jobs`     | `int`      | Live fiber count in the pool                                       |
 | `steal_attempts`   | `uint64_t` | Lifetime steal attempts for this worker (only meaningful at `STOPPED`) |
@@ -74,6 +74,7 @@
 |------------------|-------|-------------------------------------|
 | `id`             | `int` | Monotonically increasing fiber ID   |
 | `last_worker_id` | `int` | Worker that last ran this fiber (`-1` if not yet scheduled) |
+| `last_pool_id`   | `int` | Pool ID associated with the fiber at emit time |
 | `status`         | `int` | See `goc_stats_fiber_status_t`        |
 
 | `goc_stats_fiber_status_t` | Value | Meaning                      |
@@ -130,16 +131,16 @@ typedef struct goc_stats_event {
 	goc_stats_event_type_t type;
 	uint64_t timestamp;
 	union {
-		struct { void* id; int status; int thread_count; } pool;
+		struct { int id; int status; int thread_count; } pool;
 		struct {
 			int      id;
-			void*    pool_id;
+			int      pool_id;
 			int      status;
 			int      pending_jobs;
 			uint64_t steal_attempts;   /* only meaningful at STOPPED */
 			uint64_t steal_successes;  /* only meaningful at STOPPED */
 		} worker;
-		struct { int id; int last_worker_id; int status; } fiber;
+		struct { int id; int last_worker_id; int last_pool_id; int status; } fiber;
 		struct {
 			int      id;
 			int      status;
@@ -164,14 +165,14 @@ Macros emit events if telemetry is enabled, or become no-ops otherwise:
 	goc_stats_submit_event_pool((id), (status), (thread_count))
 #  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs, steal_att, steal_suc) \
 	goc_stats_submit_event_worker((id), (pool_id), (status), (pending_jobs), (steal_att), (steal_suc))
-#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status) \
-	goc_stats_submit_event_fiber((id), (last_worker_id), (status))
+#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, last_pool_id, status) \
+	goc_stats_submit_event_fiber((id), (last_worker_id), (last_pool_id), (status))
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count, ts, ps, cr, er) \
 	goc_stats_submit_event_channel((id), (status), (buf_size), (item_count), (ts), (ps), (cr), (er))
 #else
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count)                             ((void)0)
 #  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs, steal_att, suc)  ((void)0)
-#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status)                          ((void)0)
+#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, last_pool_id, status)            ((void)0)
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count, ts, ps, cr, er)  ((void)0)
 #endif
 ```
@@ -211,16 +212,16 @@ When `GOC_ENABLE_STATS` is not defined, these functions are still present but al
 After `goc_stats_init()`, all events are printed to stdout by the built-in default callback. For a program that creates a pool, spawns a fiber, and shuts down, the output looks like:
 
 ```
-[goc_stats] WORKER @ 1748000000000000000: id=0 pool=0x55a1b2c3d000 status=0 pending=0
-[goc_stats] WORKER @ 1748000000001000000: id=1 pool=0x55a1b2c3d000 status=0 pending=0
-[goc_stats] POOL @ 1748000000002000000: pool=0x55a1b2c3d000 status=0 threads=2
-[goc_stats] FIBER @ 1748000000003000000: id=0 last_worker=-1 status=0
-[goc_stats] WORKER @ 1748000000004000000: id=0 pool=0x55a1b2c3d000 status=1 pending=1
-[goc_stats] FIBER @ 1748000000005000000: id=0 last_worker=0 status=1
-[goc_stats] WORKER @ 1748000000006000000: id=0 pool=0x55a1b2c3d000 status=2 pending=0
-[goc_stats] POOL @ 1748000000007000000: pool=0x55a1b2c3d000 status=1 threads=2
-[goc_stats] WORKER @ 1748000000008000000: id=0 pool=0x55a1b2c3d000 status=3 pending=0
-[goc_stats] WORKER @ 1748000000009000000: id=1 pool=0x55a1b2c3d000 status=3 pending=0
+[goc_stats] WORKER @ 1748000000000000000: id=0 pool=0 status=0 pending=0
+[goc_stats] WORKER @ 1748000000001000000: id=1 pool=0 status=0 pending=0
+[goc_stats] POOL @ 1748000000002000000: pool=0 status=0 threads=2
+[goc_stats] FIBER @ 1748000000003000000: id=0 last_worker=-1 last_pool=0 status=0
+[goc_stats] WORKER @ 1748000000004000000: id=0 pool=0 status=1 pending=1
+[goc_stats] FIBER @ 1748000000005000000: id=0 last_worker=0 last_pool=0 status=1
+[goc_stats] WORKER @ 1748000000006000000: id=0 pool=0 status=2 pending=0
+[goc_stats] POOL @ 1748000000007000000: pool=0 status=1 threads=2
+[goc_stats] WORKER @ 1748000000008000000: id=0 pool=0 status=3 pending=0
+[goc_stats] WORKER @ 1748000000009000000: id=1 pool=0 status=3 pending=0
 ```
 
 See the [Event Types](#event-types) tables for status enum values.
@@ -249,12 +250,12 @@ int main(void) {
 ### Emitting events (internal use)
 
 ```c
-GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_CREATED, thread_count);
-GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_DESTROYED, thread_count);
+GOC_STATS_POOL_STATUS(pool_id, GOC_POOL_CREATED, thread_count);
+GOC_STATS_POOL_STATUS(pool_id, GOC_POOL_DESTROYED, thread_count);
 /* steal_attempts and steal_successes are 0 except at STOPPED */
-GOC_STATS_WORKER_STATUS(worker_id, pool, GOC_WORKER_RUNNING, pending_jobs, 0, 0);
-GOC_STATS_WORKER_STATUS(worker_id, pool, GOC_WORKER_STOPPED, 0, steal_att, steal_suc);
-GOC_STATS_FIBER_STATUS(fiber_id, last_worker_id, GOC_FIBER_CREATED);
+GOC_STATS_WORKER_STATUS(worker_id, pool_id, GOC_WORKER_RUNNING, pending_jobs, 0, 0);
+GOC_STATS_WORKER_STATUS(worker_id, pool_id, GOC_WORKER_STOPPED, 0, steal_att, steal_suc);
+GOC_STATS_FIBER_STATUS(fiber_id, last_worker_id, pool_id, GOC_FIBER_CREATED);
 /* scan/compaction counters are 0 at open; populated at close */
 GOC_STATS_CHANNEL_STATUS((int)(intptr_t)ch, 1, ch->buf_size, 0, 0, 0, 0, 0); // open
 GOC_STATS_CHANNEL_STATUS((int)(intptr_t)ch, 0, ch->buf_size, ch->item_count,

--- a/bench/README.md
+++ b/bench/README.md
@@ -14,10 +14,35 @@ using libgoc, and in Clojure using core.async.
    creation time and memory overhead for lightweight tasks.
 5. **Prime sieve** — A pipeline of filters passes numbers through channels to
    find primes, stressing long chains of tasks and sustained channel traffic.
+6. **HTTP ping-pong** — Two HTTP/1.1 servers on loopback ports bounce a counter
+   back and forth, measuring request/response overhead and integration between
+   the HTTP layer and the task scheduler.
+7. **HTTP server throughput** — One HTTP/1.1 server serves a tiny plaintext
+   response while many concurrent keep-alive clients issue GET requests,
+   measuring sustained requests/second under load.
 
 ## Running
 
 From this directory:
+
+### Combined runner
+
+From this directory, you can run all benchmark suites (Go, Clojure,
+libgoc canary, and libgoc vmem) three times each with:
+
+```sh
+./run-all.sh
+```
+
+From the repository root, the equivalent command is:
+
+```sh
+./bench/run-all.sh
+```
+
+The script clears existing `bench/logs/*.log` files first, appends fresh
+output to the per-runtime log files, and stops immediately if any benchmark
+run fails.
 
 ### Go
 
@@ -60,6 +85,8 @@ make -C clojure run-all
 | 3 | Selective receive / fan-out / fan-in | ✅ | ✅ | ✅ |
 | 4 | Spawn idle tasks | ✅ | ✅ | ✅ |
 | 5 | Prime sieve | ✅ | ✅ | ✅ |
+| 6 | HTTP ping-pong | ✅ | ✅ | ✅ |
+| 7 | HTTP server throughput | ✅ | ✅ | ✅ |
 
 ## Runs
 
@@ -77,9 +104,15 @@ make -C clojure run-all
 | **OS**          | Ubuntu 24.04.4 LTS             |
 | **Kernel**      | Linux 6.11.0 x86_64            |
 
-3 runs of each benchmark (Go, libgoc canary, libgoc vmem, Clojure) can be found in the [bench/logs/](logs/) directory. All numbers in the report below are the best of those 3 runs for each pool size.
+3 runs of each benchmark (Go, libgoc canary, libgoc vmem, Clojure) can be found in the [bench/logs/](logs/) directory. The `./run-all.sh` helper in this directory (or `./bench/run-all.sh` from the repository root) regenerates those logs. All numbers in the report below are the best of those 3 runs for each pool size.
 
 ## Report: libgoc vs. Go Baseline (+ Clojure)
+
+<!-- BEGIN AUTO BENCH REPORT -->
+
+> Note: the comparative tables below were generated before adding benchmarks
+> #6 (HTTP ping-pong) and #7 (HTTP server throughput), so they currently cover
+> the first five CSP benchmarks only.
 
 This report evaluates the performance of **libgoc canary**, **libgoc vmem**, and **Clojure core.async** relative to the **Go** runtime. All figures represent operations per second; the multiplier in parentheses indicates performance relative to the Go baseline (e.g., **1.10x** means 10% faster, **0.50x** means half the speed).
 
@@ -90,50 +123,50 @@ This report evaluates the performance of **libgoc canary**, **libgoc vmem**, and
 
 | Pool | Go (Baseline) | libgoc | libgoc vmem | Clojure |
 | :--- | :--- | :--- | :--- | :--- |
-| **1** | 2,462,723 | 1,635,016 **(0.66x)** | 567,312 **(0.23x)** | 1,475,056 **(0.60x)** |
-| **2** | 2,299,174 | 1,555,626 **(0.68x)** | 573,282 **(0.25x)** | 917,285 **(0.40x)** |
-| **4** | 2,316,612 | 1,757,418 **(0.76x)** | 696,689 **(0.30x)** | 927,094 **(0.40x)** |
-| **8** | 2,305,221 | 1,988,937 **(0.86x)** | 894,177 **(0.39x)** | 863,775 **(0.37x)** |
+| **1** | 2,462,723 | 1,600,108 **(0.65x)** | 558,292 **(0.23x)** | 1,475,056 **(0.60x)** |
+| **2** | 2,299,174 | 1,616,540 **(0.70x)** | 555,948 **(0.24x)** | 917,285 **(0.40x)** |
+| **4** | 2,316,612 | 1,825,994 **(0.79x)** | 693,443 **(0.30x)** | 927,094 **(0.40x)** |
+| **8** | 2,305,221 | 2,121,074 **(0.92x)** | 859,841 **(0.37x)** | 863,775 **(0.37x)** |
 
 ### Ring (hops/s)
 *Measures message passing latency across a circular topology.*
 
 | Pool | Go (Baseline) | libgoc | libgoc vmem | Clojure |
 | :--- | :--- | :--- | :--- | :--- |
-| **1** | 2,394,205 | 919,141 **(0.38x)** | 48,999 **(0.02x)** | 3,151,742 **(1.32x)** |
-| **2** | 2,278,856 | 786,703 **(0.35x)** | 34,749 **(0.02x)** | 2,018,366 **(0.89x)** |
-| **4** | 2,259,653 | 760,960 **(0.34x)** | 33,716 **(0.01x)** | 2,269,710 **(1.00x)** |
-| **8** | 2,263,918 | 1,042,933 **(0.46x)** | 49,230 **(0.02x)** | 2,075,803 **(0.92x)** |
+| **1** | 2,394,205 | 734,025 **(0.31x)** | 35,110 **(0.01x)** | 3,151,742 **(1.32x)** |
+| **2** | 2,278,856 | 691,170 **(0.30x)** | 34,654 **(0.02x)** | 2,018,366 **(0.89x)** |
+| **4** | 2,259,653 | 998,693 **(0.44x)** | 50,900 **(0.02x)** | 2,269,710 **(1.00x)** |
+| **8** | 2,263,918 | 942,573 **(0.42x)** | 49,061 **(0.02x)** | 2,075,803 **(0.92x)** |
 
 ### Selective receive / fan-out / fan-in (msg/s)
 *Evaluates complex orchestration and selection logic.*
 
 | Pool | Go (Baseline) | libgoc | libgoc vmem | Clojure |
 | :--- | :--- | :--- | :--- | :--- |
-| **1** | 640,172 | 220,347 **(0.34x)** | 223,037 **(0.35x)** | 344,863 **(0.54x)** |
-| **2** | 707,669 | 217,599 **(0.31x)** | 222,069 **(0.31x)** | 376,259 **(0.53x)** |
-| **4** | 755,743 | 198,436 **(0.26x)** | 223,638 **(0.30x)** | 378,694 **(0.50x)** |
-| **8** | 764,424 | 217,015 **(0.28x)** | 242,620 **(0.32x)** | 369,592 **(0.48x)** |
+| **1** | 640,172 | 201,047 **(0.31x)** | 241,784 **(0.38x)** | 344,863 **(0.54x)** |
+| **2** | 707,669 | 192,201 **(0.27x)** | 246,297 **(0.35x)** | 376,259 **(0.53x)** |
+| **4** | 755,743 | 198,760 **(0.26x)** | 240,128 **(0.32x)** | 378,694 **(0.50x)** |
+| **8** | 764,424 | 188,333 **(0.25x)** | 242,987 **(0.32x)** | 369,592 **(0.48x)** |
 
 ### Spawn idle tasks (tasks/s)
 *Tests the efficiency of task creation and scheduling.*
 
 | Pool | Go (Baseline) | libgoc | libgoc vmem | Clojure |
 | :--- | :--- | :--- | :--- | :--- |
-| **1** | 237,190 | 157,846 **(0.67x)** | 65,844 **(0.28x)** | 815,298 **(3.44x)** |
-| **2** | 419,821 | 71,358 **(0.17x)** | 57,712 **(0.14x)** | 917,459 **(2.19x)** |
-| **4** | 563,616 | 73,200 **(0.13x)** | 57,051 **(0.10x)** | 842,494 **(1.49x)** |
-| **8** | 583,660 | 74,095 **(0.13x)** | 17,572 **(0.03x)** | 905,371 **(1.55x)** |
+| **1** | 237,190 | 169,533 **(0.71x)** | 66,555 **(0.28x)** | 815,298 **(3.44x)** |
+| **2** | 419,821 | 75,506 **(0.18x)** | 16,195 **(0.04x)** | 917,459 **(2.19x)** |
+| **4** | 563,616 | 76,238 **(0.14x)** | 56,376 **(0.10x)** | 842,494 **(1.49x)** |
+| **8** | 583,660 | 70,784 **(0.12x)** | 56,404 **(0.10x)** | 905,371 **(1.55x)** |
 
 ### Prime sieve (primes/s)
 *High-concurrency filtering test.*
 
 | Pool | Go (Baseline) | libgoc | libgoc vmem | Clojure |
 | :--- | :--- | :--- | :--- | :--- |
-| **1** | 2,024 | 2,976 **(1.47x)** | 869 **(0.43x)** | 2,099 **(1.04x)** |
-| **2** | 4,088 | 2,962 **(0.72x)** | 830 **(0.20x)** | 2,314 **(0.57x)** |
-| **4** | 7,747 | 2,790 **(0.36x)** | 828 **(0.11x)** | 1,853 **(0.24x)** |
-| **8** | 14,297 | 2,933 **(0.21x)** | 842 **(0.06x)** | 1,805 **(0.13x)** |
+| **1** | 2,024 | 2,829 **(1.40x)** | 776 **(0.38x)** | 2,099 **(1.04x)** |
+| **2** | 4,088 | 2,889 **(0.71x)** | 640 **(0.16x)** | 2,314 **(0.57x)** |
+| **4** | 7,747 | 2,878 **(0.37x)** | 822 **(0.11x)** | 1,853 **(0.24x)** |
+| **8** | 14,297 | 2,907 **(0.20x)** | 853 **(0.06x)** | 1,805 **(0.13x)** |
 
 ---
 
@@ -143,16 +176,18 @@ Geometric mean of the ×Go multipliers across pool sizes 1, 2, 4, 8.
 
 | Benchmark | libgoc (canary) | libgoc (vmem) | Clojure |
 | :--- | :---: | :---: | :---: |
-| Ping-pong | 0.74× | 0.29× | 0.43× |
-| Ring | 0.38× | 0.02× | 1.02× |
-| Fan-out/Fan-in | 0.30× | 0.32× | 0.51× |
+| Ping-pong | 0.76× | 0.28× | 0.43× |
+| Ring | 0.36× | 0.02× | 1.02× |
+| Fan-out/Fan-in | 0.27× | 0.34× | 0.51× |
 | Spawn idle | 0.21× | 0.10× | 2.04× |
-| Prime sieve | 0.53× | 0.15× | 0.37× |
+| Prime sieve | 0.52× | 0.14× | 0.36× |
 
 **Takeaways:**
-- libgoc canary's ping-pong performance reaches 0.86× Go at pool=8, with a geometric mean of 0.74×—solid scaling, though still trailing Go at lower pool sizes.
-- Ring throughput for canary crosses 1M hops/s at pool=8 (0.46× Go), with a geometric mean of 0.38×. vmem remains extremely slow on this test (0.02×) due to TLB/page-fault pressure.
-- Fan-out/fan-in: canary (0.30×) and vmem (0.32×) are nearly identical, both well below Clojure (0.51×) and Go.
-- Spawn idle tasks: canary geomean drops to 0.21× Go due to steal thrashing at pool≥2 — work stealing causes excessive wakeup contention for tasks that immediately park. vmem (0.10×) is also impacted. Clojure's advantage (2.04×) comes from heap-allocated, stack-free go-blocks.
-- Prime sieve: canary (0.53×) outpaces Clojure (0.37×) and beats Go at pool=1 (1.47×). vmem lags (0.15×).
-- Overall, canary ring and ping-pong scale well with thread count. The spawn idle regression at pool≥2 is the primary open issue for the current optimization phase.
+- libgoc canary ping-pong now peaks at 0.92× Go at pool=8, with a geometric mean of 0.76× (up from the previous snapshot), showing continued scaling progress.
+- Ring remains a weak point for canary (0.36× geomean), with best throughput at pool=4 (998,693 hops/s, 0.44× Go). vmem stays bottlenecked at ~0.02× due to virtual-memory stack overhead.
+- Fan-out/fan-in shifted in vmem’s favor in this run set: vmem reaches a 0.34× geomean versus canary at 0.27×, though both are still below Clojure (0.51×) and Go.
+- Spawn idle tasks is still the largest canary regression under contention: 0.21× geomean, dropping sharply past pool=1. vmem remains volatile here (notably 0.04× at pool=2), while Clojure retains a large advantage (2.04×).
+- Prime sieve: canary remains strongest at pool=1 (1.40× Go) but trails at higher pool sizes, landing at 0.52× geomean. vmem is at 0.14× and Clojure at 0.36×.
+- Overall, canary shows clear gains in ping-pong and maintains competitive single-thread sieve behavior, but ring and especially spawn-idle scalability continue to dominate the optimization backlog.
+
+<!-- END AUTO BENCH REPORT -->

--- a/bench/clojure/README.md
+++ b/bench/clojure/README.md
@@ -1,7 +1,7 @@
 # Clojure core.async Benchmarks
 
 Standalone CSP benchmarks implemented in Clojure using
-[`core.async`](https://github.com/clojure/core.async).  All five benchmarks
+[`core.async`](https://github.com/clojure/core.async).  All seven benchmarks
 mirror those in `bench/go/main.go` and `bench/libgoc/bench.c` for a direct
 three-way performance comparison.
 
@@ -35,6 +35,8 @@ The `POOL_SIZE` variable sets the JVM system property
 | 3 | **Selective receive / fan-out / fan-in** | Producer → N workers → `alts!` collector |
 | 4 | **Spawn idle tasks** | Spawn N go-blocks that park immediately, then wake them |
 | 5 | **Prime sieve** | Concurrent Eratosthenes pipeline |
+| 6 | **HTTP ping-pong** | Two HTTP/1.1 servers bounce a counter between each other |
+| 7 | **HTTP server throughput** | One server serves plaintext while concurrent keep-alive clients load it |
 
 ## Output Format
 

--- a/bench/clojure/deps.edn
+++ b/bench/clojure/deps.edn
@@ -1,3 +1,4 @@
 {:deps  {org.clojure/clojure    {:mvn/version "1.11.4"}
-         org.clojure/core.async {:mvn/version "1.6.681"}}
+         org.clojure/core.async {:mvn/version "1.6.681"}
+         http-kit/http-kit      {:mvn/version "2.8.0"}}
  :paths ["src"]}

--- a/bench/clojure/src/bench/core.clj
+++ b/bench/clojure/src/bench/core.clj
@@ -1,6 +1,6 @@
 ; bench/clojure/src/bench/core.clj — CSP concurrency benchmarks for Clojure core.async
 ;
-; Five micro-benchmarks that mirror bench/go/main.go and bench/libgoc/bench.c
+; Seven micro-benchmarks that mirror bench/go/main.go and bench/libgoc/bench.c
 ; so that Go, libgoc, and Clojure results can be compared directly.
 ;
 ; Benchmarks
@@ -10,6 +10,9 @@
 ; 3. Selective receive / fan-out / fan-in — producer → N workers → alts! collector.
 ; 4. Spawn idle tasks — spawn N go-blocks that park immediately, then wake them all.
 ; 5. Prime sieve — concurrent Eratosthenes pipeline of go-block filter stages.
+; 6. HTTP ping-pong — two http-kit servers bounce a counter over HTTP/1.1.
+; 7. HTTP server throughput — one http-kit server serves a tiny plaintext
+;    response while many concurrent keep-alive clients issue GET requests.
 ;
 ; Running
 ; -------
@@ -19,7 +22,10 @@
 
 (ns bench.core
   (:require [clojure.core.async :as a
-             :refer [go go-loop chan <! >! <!! >!! close! alts!]]))
+             :refer [go go-loop chan <! >! <!! >!! close! alts!]]
+            [clojure.string :as str]
+            [org.httpkit.server :as http-server]
+            [org.httpkit.client :as http-client]))
 
 (def ^:private ping-rounds    200000)
 (def ^:private ring-nodes     128)
@@ -28,6 +34,11 @@
 (def ^:private select-tasks   200000)
 (def ^:private spawn-count    200000)
 (def ^:private prime-max      20000)
+(def ^:private http-rounds    2000)
+(def ^:private http-tp-concurrency 32)
+(def ^:private http-tp-warmup-ms   1000)
+(def ^:private http-tp-measure-ms  5000)
+
 
 
 ; ============================================================================
@@ -228,19 +239,124 @@
               count max ms rate))))
 
 
+(defn bench-http-ping-pong [rounds]
+  (let [warmup     (max 100 (long (/ rounds 10)))
+        total      (+ warmup rounds)
+        done-ch    (chan)
+        samples    (long-array rounds)
+        meas-start (atom 0)
+        meas-end   (atom 0)
+        url-a      "http://127.0.0.1:19090/ping"
+        url-b      "http://127.0.0.1:19091/ping"
+        parse-msg  (fn [s]
+                     (let [[n t] (str/split (str/trim s) #"," 2)
+                           n'    (Long/parseLong n)
+                           t'    (if (and t (not (str/blank? t)))
+                                   (Long/parseLong t)
+                                   0)]
+                       [n' t']))
+        handler-a  (fn [req]
+                     (let [[n sent-ns] (parse-msg (slurp (:body req)))
+                           now         (System/nanoTime)]
+                       (when (and (> n warmup) (<= n total) (pos? sent-ns))
+                         (aset-long samples (int (- n warmup 1)) (- now sent-ns)))
+                       (if (>= n total)
+                         (do (reset! meas-end now)
+                             (close! done-ch))
+                         (do
+                           (when (= n warmup)
+                             (reset! meas-start now))
+                             @(http-client/post url-b {:body (str (inc n) "," (System/nanoTime))})))
+                       {:status 200 :body "ok"}))
+        handler-b  (fn [req]
+                     (let [[n sent-ns] (parse-msg (slurp (:body req)))]
+                           @(http-client/post url-a {:body (str n "," sent-ns)})
+                       {:status 200 :body "ok"}))
+        srv-a      (http-server/run-server handler-a {:port 19090})
+        srv-b      (http-server/run-server handler-b {:port 19091})]
+    @(http-client/post url-a {:body "0,0"})
+    (<!! done-ch)
+    (let [start-ns (if (pos? @meas-start) @meas-start (System/nanoTime))
+          end-ns   (if (> @meas-end start-ns) @meas-end (inc start-ns))
+          meas-ns  (- end-ns start-ns)
+          s        (/ meas-ns 1e9)
+          ms       (long (/ meas-ns 1e6))
+          vals     (vec samples)
+          sorted   (vec (sort vals))
+          idx      (fn [pct]
+                     (int (Math/round (/ (* pct (dec rounds)) 100.0))))
+          p50-us   (/ (double (nth sorted (idx 50))) 1000.0)
+          p95-us   (/ (double (nth sorted (idx 95))) 1000.0)
+          p99-us   (/ (double (nth sorted (idx 99))) 1000.0)
+          avg-us   (/ (/ (double (reduce + vals)) rounds) 1000.0)
+          rate     (/ rounds s)]
+      (srv-a)
+      (srv-b)
+      (printf "HTTP ping-pong: %d round trips in %dms (%.0f round trips/s, avg %.1fus p50 %.1fus p95 %.1fus p99 %.1fus, warmup %d)\n"
+              rounds ms rate avg-us p50-us p95-us p99-us warmup))))
+
+
+; ============================================================================
+; 7. HTTP server throughput
+; ============================================================================
+
+(defn bench-http-server-throughput [concurrency warmup-ms measure-ms]
+  (when (and (pos? concurrency) (>= warmup-ms 0) (pos? measure-ms))
+    (let [url             "http://127.0.0.1:19100/plaintext"
+          handler         (fn [_req] {:status 200 :body "OK"})
+          stop-server     (http-server/run-server handler {:port 19100})
+          warmup-end-ns   (+ (System/nanoTime) (* warmup-ms 1000000))
+          measure-end-ns  (+ warmup-end-ns (* measure-ms 1000000))
+          workers         (mapv (fn [_]
+                                  (future
+                                    (loop [succ 0
+                                           err  0]
+                                      (if (>= (System/nanoTime) measure-end-ns)
+                                        {:succ succ :err err}
+                                        (let [resp      (try
+                                                          @(http-client/get url {:timeout 1000})
+                                                          (catch Throwable _
+                                                            {:status 0}))
+                                              done-ns   (System/nanoTime)
+                                              in-window (and (>= done-ns warmup-end-ns)
+                                                             (< done-ns measure-end-ns))
+                                              ok?       (= 200 (:status resp))]
+                                          (cond
+                                            (and in-window ok?)
+                                            (recur (inc succ) err)
+
+                                            in-window
+                                            (recur succ (inc err))
+
+                                            :else
+                                            (recur succ err)))))))
+                                (range concurrency))
+          totals          (reduce (fn [{acc-succ :succ acc-err :err}
+                                      {w-succ :succ w-err :err}]
+                                    {:succ (+ acc-succ w-succ)
+                                     :err  (+ acc-err w-err)})
+                                  {:succ 0 :err 0}
+                                  (mapv deref workers))
+          seconds         (/ measure-ms 1000.0)
+          rate            (/ (:succ totals) seconds)]
+      (stop-server)
+      (printf "HTTP server throughput: %d requests in %dms (%.0f req/s, %d errors, concurrency %d, warmup %dms)\n"
+              (:succ totals) measure-ms rate (:err totals) concurrency warmup-ms))))
+
+
 ; ============================================================================
 ; main
 ; ============================================================================
 
 (defn -main [& _args]
-  (let [pool-size (Long/parseLong
-                   (System/getProperty "clojure.core.async.pool-size" "8"))]
-    (printf "CLOJURE_POOL_THREADS=%d\n" pool-size)
-    (flush))
-  (bench-ping-pong    ping-rounds)
-  (bench-ring         ring-nodes ring-hops)
-  (bench-fan-in       select-workers select-tasks)
-  (bench-spawn-idle   spawn-count)
-  (bench-prime-sieve  prime-max)
+  (bench-ping-pong   ping-rounds)
+  (bench-ring        ring-nodes ring-hops)
+  (bench-fan-in      select-workers select-tasks)
+  (bench-spawn-idle  spawn-count)
+  (bench-prime-sieve prime-max)
+  (bench-http-ping-pong http-rounds)
+  (bench-http-server-throughput http-tp-concurrency
+                                http-tp-warmup-ms
+                                http-tp-measure-ms)
   (flush)
   (shutdown-agents))

--- a/bench/go/README.md
+++ b/bench/go/README.md
@@ -1,6 +1,6 @@
 # Go Benchmarks
 
-Standalone CSP benchmarks implemented in Go.  All five benchmarks are enabled
+Standalone CSP benchmarks implemented in Go.  All seven benchmarks are enabled
 and mirror those in `bench/libgoc/bench.c` for a direct performance comparison.
 
 ## Running
@@ -22,6 +22,8 @@ make run-all
 | 3 | **Selective receive / fan-out / fan-in** | Producer → N workers → `reflect.Select` collector |
 | 4 | **Spawn idle tasks** | Spawn N goroutines that block immediately, then wake them |
 | 5 | **Prime sieve** | Concurrent Eratosthenes pipeline |
+| 6 | **HTTP ping-pong** | Two HTTP/1.1 servers bounce a counter between each other |
+| 7 | **HTTP server throughput** | One server serves plaintext while concurrent keep-alive clients load it |
 
 ## Output Format
 

--- a/bench/go/main.go
+++ b/bench/go/main.go
@@ -1,7 +1,7 @@
 /*
 Package main contains standalone CSP concurrency benchmarks for Go.
 
-Five micro-benchmarks exercise different aspects of Go's goroutine scheduler
+Seven micro-benchmarks exercise different aspects of Go's goroutine scheduler
 and channel primitives.  The benchmarks mirror those in bench/libgoc/bench.c
 so that Go and libgoc results can be compared directly.
 
@@ -17,6 +17,11 @@ Benchmarks
      on a shared channel, then wake them all; measures creation and wakeup cost.
   5. Prime sieve — a concurrent pipeline where each stage filters multiples of a
      discovered prime, stressing long chains of goroutines and sustained traffic.
+  6. HTTP ping-pong — two HTTP/1.1 servers on loopback ports bounce a counter
+     back and forth, exercising net/http server/client throughput.
+  7. HTTP server throughput — one HTTP/1.1 server serves a tiny plaintext
+	  response while many concurrent keep-alive clients issue GET requests,
+	  measuring sustained requests/second under load.
 
 Usage:
   go run .                    # single run (current GOMAXPROCS)
@@ -27,7 +32,13 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"reflect"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -40,12 +51,21 @@ func main() {
 	selectTasks   := 200000
 	spawnCount    := 200000
 	primeMax      := 20000
+	// Lower than CSP benchmarks: net/http pools connections, but each new
+	// connection pair still adds setup overhead.  2000 rounds gives a fast,
+	// stable rate measurement.
+	httpRounds    := 2000
+	httpTPConcurrency := 32
+	httpTPWarmupMs := 1000
+	httpTPMeasureMs := 5000
 
 	pingPong(pingRounds)
 	ringBenchmark(ringNodes, ringHops)
 	fanInBenchmark(selectWorkers, selectTasks)
 	spawnIdle(spawnCount)
 	primeSieve(primeMax)
+	httpPingPong(httpRounds)
+	httpServerThroughput(httpTPConcurrency, httpTPWarmupMs, httpTPMeasureMs)
 }
 
 
@@ -332,4 +352,262 @@ func filter(in <-chan int, prime int) <-chan int {
 		close(out)
 	}()
 	return out
+}
+
+
+// ============================================================================
+// 6. HTTP ping-pong
+// ============================================================================
+
+// httpPingPong measures HTTP/1.1 loopback request/response throughput.
+//
+	// Two servers (A and B) bounce a counter back and forth. Server A reads the
+	// counter, writes "ok", then forwards counter+1 to B and waits for that
+	// request to complete. Server B does the same back to A. When A sees counter
+	// >= rounds it closes `done` instead of forwarding.
+//
+// Go's http.Client reuses keep-alive connections by default, so throughput
+// here is higher than for libgoc (which opens a new TCP connection per
+// request). The numbers are still included for end-to-end comparison.
+//
+// Uses fixed loopback ports (19090/19091) and /ping endpoints to mirror the
+// libgoc and Clojure benchmark setup as closely as possible.
+// The initial POST is synchronous so the timer starts only after the first
+// server handshake has been initiated.
+func httpPingPong(rounds int) {
+	const addrA = "127.0.0.1:19090"
+	const addrB = "127.0.0.1:19091"
+	const urlA = "http://127.0.0.1:19090/ping"
+	const urlB = "http://127.0.0.1:19091/ping"
+
+	warmup := rounds / 10
+	if warmup < 100 {
+		warmup = 100
+	}
+	total := warmup + rounds
+
+	done := make(chan struct{})
+	var doneOnce sync.Once
+	latNs := make([]int64, rounds)
+	var measStart int64
+	var measEnd int64
+
+	lnA, err := net.Listen("tcp", addrA)
+	if err != nil {
+		fmt.Printf("HTTP ping-pong: listen error on %s: %v\n", addrA, err)
+		return
+	}
+	lnB, err := net.Listen("tcp", addrB)
+	if err != nil {
+		lnA.Close()
+		fmt.Printf("HTTP ping-pong: listen error on %s: %v\n", addrB, err)
+		return
+	}
+
+	client := &http.Client{}
+
+	muxA := http.NewServeMux()
+	muxA.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		n, sentNs := parseCounterStamp(string(body))
+		now := time.Now().UnixNano()
+		w.Write([]byte("ok"))
+
+		if n > warmup && n <= total && sentNs > 0 {
+			latNs[n-warmup-1] = now - sentNs
+		}
+
+		if n >= total {
+			measEnd = now
+			doneOnce.Do(func() { close(done) })
+			return
+		}
+		if n == warmup {
+			measStart = now
+		}
+
+		resp, _ := client.Post(urlB, "text/plain",
+			strings.NewReader(fmt.Sprintf("%d,%d", n+1, time.Now().UnixNano())))
+		if resp != nil {
+			resp.Body.Close()
+		}
+	})
+
+	muxB := http.NewServeMux()
+	muxB.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		n, sentNs := parseCounterStamp(string(body))
+		w.Write([]byte("ok"))
+		resp, _ := client.Post(urlA, "text/plain",
+			strings.NewReader(fmt.Sprintf("%d,%d", n, sentNs)))
+		if resp != nil {
+			resp.Body.Close()
+		}
+	})
+
+	srvA := &http.Server{Handler: muxA}
+	srvB := &http.Server{Handler: muxB}
+	go srvA.Serve(lnA)
+	go srvB.Serve(lnB)
+
+	resp, _ := client.Post(urlA, "text/plain", strings.NewReader("0,0"))
+	if resp != nil {
+		resp.Body.Close()
+	}
+	<-done
+
+	if measStart == 0 || measEnd <= measStart {
+		measStart = time.Now().UnixNano()
+		measEnd = measStart + 1
+	}
+	measured := time.Duration(measEnd - measStart)
+
+	srvA.Close()
+	srvB.Close()
+
+	sorted := append([]int64(nil), latNs...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	var sum int64
+	for _, v := range latNs {
+		sum += v
+	}
+
+	ms := int(measured.Nanoseconds() / 1_000_000)
+	rate := float64(rounds) / measured.Seconds()
+	avgUs := float64(sum) / float64(rounds) / 1000.0
+	p50Us := percentileUs(sorted, 50)
+	p95Us := percentileUs(sorted, 95)
+	p99Us := percentileUs(sorted, 99)
+
+	fmt.Printf("HTTP ping-pong: %d round trips in %dms (%.0f round trips/s, avg %.1fus p50 %.1fus p95 %.1fus p99 %.1fus, warmup %d)\n",
+		rounds, ms, rate, avgUs, p50Us, p95Us, p99Us, warmup)
+}
+
+func parseCounterStamp(s string) (int, int64) {
+	parts := strings.SplitN(strings.TrimSpace(s), ",", 2)
+	if len(parts) == 0 {
+		return 0, 0
+	}
+	n, _ := strconv.Atoi(parts[0])
+	if len(parts) < 2 {
+		return n, 0
+	}
+	t, _ := strconv.ParseInt(parts[1], 10, 64)
+	return n, t
+}
+
+func percentileUs(sorted []int64, pct int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (pct*(len(sorted)-1) + 50) / 100
+	return float64(sorted[idx]) / 1000.0
+}
+
+
+// ============================================================================
+// 7. HTTP server throughput
+// ============================================================================
+
+// httpServerThroughput measures sustained HTTP plaintext throughput.
+//
+// One loopback server serves GET /plaintext with body "OK". `concurrency`
+// worker goroutines continuously issue keep-alive GET requests and count
+// completions in the measurement window after warmup.
+func httpServerThroughput(concurrency int, warmupMs int, measureMs int) {
+	if concurrency <= 0 || warmupMs < 0 || measureMs <= 0 {
+		return
+	}
+
+	const addr = "127.0.0.1:19100"
+	url := "http://" + addr + "/plaintext"
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		fmt.Printf("HTTP server throughput: listen error: %v\n", err)
+		return
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plaintext", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+
+	transport := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConns:        concurrency * 2,
+		MaxIdleConnsPerHost: concurrency * 2,
+		IdleConnTimeout:     30 * time.Second,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   1 * time.Second,
+	}
+
+	start := time.Now()
+	warmupEnd := start.Add(time.Duration(warmupMs) * time.Millisecond)
+	measureEnd := warmupEnd.Add(time.Duration(measureMs) * time.Millisecond)
+
+	succ := make([]uint64, concurrency)
+	errs := make([]uint64, concurrency)
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		idx := i
+		go func() {
+			defer wg.Done()
+			var okCount uint64
+			var errCount uint64
+
+			for {
+				if !time.Now().Before(measureEnd) {
+					break
+				}
+
+				resp, reqErr := client.Get(url)
+				done := time.Now()
+				inWindow := !done.Before(warmupEnd) && done.Before(measureEnd)
+
+				if reqErr == nil && resp != nil {
+					io.Copy(io.Discard, resp.Body)
+					status := resp.StatusCode
+					resp.Body.Close()
+					if inWindow {
+						if status == http.StatusOK {
+							okCount++
+						} else {
+							errCount++
+						}
+					}
+				} else if inWindow {
+					errCount++
+				}
+			}
+
+			succ[idx] = okCount
+			errs[idx] = errCount
+		}()
+	}
+
+	wg.Wait()
+	srv.Close()
+	transport.CloseIdleConnections()
+
+	var totalSucc uint64
+	var totalErr uint64
+	for i := 0; i < concurrency; i++ {
+		totalSucc += succ[i]
+		totalErr += errs[i]
+	}
+
+	seconds := float64(measureMs) / 1000.0
+	rate := float64(totalSucc) / seconds
+	fmt.Printf("HTTP server throughput: %d requests in %dms (%.0f req/s, %d errors, concurrency %d, warmup %dms)\n",
+		totalSucc, measureMs, rate, totalErr, concurrency, warmupMs)
 }

--- a/bench/libgoc/README.md
+++ b/bench/libgoc/README.md
@@ -45,7 +45,7 @@ an explicit positive cap for repeatable stress testing.
 
 ## Benchmarks
 
-All five benchmarks are **implemented and enabled** in `bench.c`.
+All seven benchmarks are **implemented and enabled** in `bench.c`.
 
 | # | Name | Status |
 |---|------|--------|
@@ -54,6 +54,8 @@ All five benchmarks are **implemented and enabled** in `bench.c`.
 | 3 | **Selective receive / fan-out / fan-in** — producer → N workers → `goc_alts` collector | ✅ enabled |
 | 4 | **Spawn idle tasks** — spawn many fibers that park immediately, then wake them | ✅ enabled |
 | 5 | **Prime sieve** — concurrent Eratosthenes pipeline | ✅ enabled |
+| 6 | **HTTP ping-pong** — two HTTP/1.1 servers bounce a counter back and forth | ✅ enabled |
+| 7 | **HTTP server throughput** — one server serves plaintext under keep-alive client load | ✅ enabled |
 
 ## Output Format
 
@@ -71,6 +73,8 @@ Ring benchmark: 500000 hops across 128 tasks in 495ms (1008686 hops/s)
 Selective receive / fan-out / fan-in: 200000 messages with 8 workers in 840ms (238041 msg/s)
 Spawn idle tasks: 200000 fibers in 1203ms (166231 tasks/s)
 Prime sieve: 2262 primes up to 20000 in 877ms (2577 primes/s)
+HTTP ping-pong: <rounds> round trips in <ms>ms (<rate> round trips/s, avg <us> p50 <us> p95 <us> p99 <us>, warmup <rounds>)
+HTTP server throughput: <requests> requests in <ms>ms (<rate> req/s, <errors> errors, concurrency <n>, warmup <ms>ms)
 ```
 
 ## Multi-Pool Testing

--- a/bench/libgoc/bench.c
+++ b/bench/libgoc/bench.c
@@ -1,7 +1,7 @@
 /*
  * bench/libgoc/bench.c — CSP concurrency benchmarks for libgoc
  *
- * Five micro-benchmarks that stress different aspects of the libgoc runtime.
+ * Seven micro-benchmarks that stress different aspects of the libgoc runtime.
  * Each benchmark is self-contained and can be read independently.
  *
  * Benchmarks
@@ -27,6 +27,14 @@
  *    multiples of a discovered prime.  Stresses long chains of fibers and
  *    sustained channel traffic.
  *
+ * 6. HTTP ping-pong — two HTTP/1.1 servers on loopback ports bounce a
+ *    counter back and forth, measuring end-to-end request/response overhead
+ *    including TCP I/O and integration with the libgoc HTTP layer.
+ *
+ * 7. HTTP server throughput — one HTTP/1.1 server serves a tiny plaintext
+ *    response while many concurrent keep-alive clients issue GET requests,
+ *    measuring sustained requests/second under load.
+ *
  * Building
  * --------
  *   make -C bench/libgoc build          # single build
@@ -49,11 +57,14 @@
  */
 
 #include "goc.h"
+#include "goc_http.h"
 #include "goc_stats.h"
 
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <uv.h>
 
 
@@ -394,8 +405,6 @@ static void bench_fan_in(size_t workers, size_t tasks) {
  * This measures:
  *   - Fiber creation throughput (goc_go cost × count)
  *   - Mass wakeup throughput (goc_close broadcasting to all parked fibers)
- *
- * NOTE: This benchmark is currently disabled in main().
  */
 
 /*
@@ -449,8 +458,6 @@ static void bench_spawn_idle(size_t count) {
  *
  * This stresses long chains of fibers and sustained point-to-point channel
  * traffic over the full run.
- *
- * NOTE: This benchmark is currently disabled in main().
  */
 
 typedef struct {
@@ -565,6 +572,286 @@ static void bench_prime_sieve(size_t max) {
 
 
 /* =========================================================================
+ * 6. HTTP ping-pong benchmark
+ * =========================================================================
+ *
+ * Two HTTP/1.1 servers (A on port 19090, B on port 19091) bounce a counter
+ * back and forth, mirroring the ping-pong example in HTTP.md.
+ *
+ * Server A (POST /ping): reads the counter, responds "ok", then forwards
+ * counter+1 to server B.  When counter >= rounds it closes `done` and stops.
+ * Server B (POST /ping): reads the counter, responds "ok", then forwards
+ * counter+1 back to server A.
+ *
+ * Timing: starts just before the first fire-and-forget POST to A, ends when
+ * `done` is closed (i.e., after `rounds` HTTP round trips have completed).
+ *
+ * NOTE: The round count is intentionally lower than the CSP benchmarks
+ * because the current libgoc HTTP client opens a new TCP connection for
+ * every request.  The benchmark still exercises the HTTP server, client,
+ * and fiber-scheduling integration end-to-end.
+ */
+
+#define HTTP_PP_PORT_A 19090
+#define HTTP_PP_PORT_B 19091
+#define HTTP_PP_URL_A  "http://127.0.0.1:19090/ping"
+#define HTTP_PP_URL_B  "http://127.0.0.1:19091/ping"
+
+/*
+ * State shared between the two HTTP handler fibers.
+ * Written once in bench_http_ping_pong before the servers start; read-only
+ * thereafter (safe: the ping-pong chain is sequential).
+ */
+static struct {
+    goc_chan* done;
+    size_t    warmup;
+    size_t    measured;
+    size_t    total;
+    uint64_t* lat_ns;
+    uint64_t  t_meas_start;
+    uint64_t  t_meas_end;
+} g_http_pp;
+
+static int cmp_u64(const void* a, const void* b) {
+    const uint64_t va = *(const uint64_t*)a;
+    const uint64_t vb = *(const uint64_t*)b;
+    return (va > vb) - (va < vb);
+}
+
+static double percentile_us(const uint64_t* sorted, size_t n, int pct) {
+    if (n == 0)
+        return 0.0;
+    size_t idx = (size_t)(((uint64_t)pct * (uint64_t)(n - 1) + 50u) / 100u);
+    return (double)sorted[idx] / 1000.0;
+}
+
+/*
+ * http_pp_handler_a — POST /ping handler for server A.
+ *
+ * Responds "ok" to the caller, then forwards counter+1 to server B.
+ * Closes `done` instead of forwarding when the round limit is reached.
+ */
+static void http_pp_handler_a(goc_http_ctx_t* ctx) {
+    int n = 0;
+    uint64_t sent_ns = 0;
+    const char* body = goc_http_server_body_str(ctx);
+    (void)sscanf(body, "%d,%" SCNu64, &n, &sent_ns);
+
+    uint64_t now = uv_hrtime();
+    goc_take(goc_http_server_respond(ctx, 200, "text/plain", "ok"));
+
+    if ((size_t)n > g_http_pp.warmup && (size_t)n <= g_http_pp.total && sent_ns > 0) {
+        size_t idx = (size_t)n - g_http_pp.warmup - 1;
+        g_http_pp.lat_ns[idx] = now - sent_ns;
+    }
+
+    if ((size_t)n >= g_http_pp.total) {
+        g_http_pp.t_meas_end = now;
+        goc_close(g_http_pp.done);
+        return;
+    }
+
+    if ((size_t)n == g_http_pp.warmup)
+        g_http_pp.t_meas_start = now;
+
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    /* Keep relay synchronous so benchmark teardown does not race with
+     * in-flight client write callbacks. */
+    goc_take(goc_http_post(HTTP_PP_URL_B, "text/plain",
+                           goc_sprintf("%d,%" PRIu64, n + 1, uv_hrtime()),
+                           opts));
+}
+
+/*
+ * http_pp_handler_b — POST /ping handler for server B.
+ *
+ * Responds "ok" to the caller, then forwards counter+1 back to server A.
+ */
+static void http_pp_handler_b(goc_http_ctx_t* ctx) {
+    int n = 0;
+    uint64_t sent_ns = 0;
+    const char* body = goc_http_server_body_str(ctx);
+    (void)sscanf(body, "%d,%" SCNu64, &n, &sent_ns);
+
+    goc_take(goc_http_server_respond(ctx, 200, "text/plain", "ok"));
+
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    /* Keep relay synchronous so benchmark teardown does not race with
+     * in-flight client write callbacks. */
+    goc_take(goc_http_post(HTTP_PP_URL_A, "text/plain",
+                           goc_sprintf("%d,%" PRIu64, n, sent_ns), opts));
+}
+
+/*
+ * bench_http_ping_pong — run HTTP ping-pong for `rounds` round trips.
+ *
+ * Starts two servers, fires the initial request, waits for completion, then
+ * shuts both servers down gracefully before returning.
+ */
+static void bench_http_ping_pong(size_t rounds) {
+    g_http_pp.done   = goc_chan_make(0);
+    g_http_pp.measured = rounds;
+    g_http_pp.warmup   = rounds / 10;
+    if (g_http_pp.warmup < 100)
+        g_http_pp.warmup = 100;
+    g_http_pp.total      = g_http_pp.warmup + g_http_pp.measured;
+    g_http_pp.lat_ns     = (uint64_t*)goc_malloc(sizeof(uint64_t) * g_http_pp.measured);
+    g_http_pp.t_meas_start = 0;
+    g_http_pp.t_meas_end   = 0;
+
+    goc_http_server_t* srv_a = goc_http_server_make(goc_http_server_opts());
+    goc_http_server_route(srv_a, "POST", "/ping", http_pp_handler_a);
+    goc_chan* ready_a = goc_http_server_listen(srv_a, "127.0.0.1", HTTP_PP_PORT_A);
+
+    goc_http_server_t* srv_b = goc_http_server_make(goc_http_server_opts());
+    goc_http_server_route(srv_b, "POST", "/ping", http_pp_handler_b);
+    goc_chan* ready_b = goc_http_server_listen(srv_b, "127.0.0.1", HTTP_PP_PORT_B);
+
+    goc_take(ready_a);
+    goc_take(ready_b);
+
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(HTTP_PP_URL_A, "text/plain", "0,0", opts);
+    goc_take(g_http_pp.done);
+
+    if (g_http_pp.t_meas_start == 0 || g_http_pp.t_meas_end <= g_http_pp.t_meas_start) {
+        g_http_pp.t_meas_start = uv_hrtime();
+        g_http_pp.t_meas_end = g_http_pp.t_meas_start + 1;
+    }
+
+    goc_take(goc_http_server_close(srv_a));
+    goc_take(goc_http_server_close(srv_b));
+
+    uint64_t meas_ns = g_http_pp.t_meas_end - g_http_pp.t_meas_start;
+    double s    = (double)meas_ns / 1e9;
+    int    ms   = (int)(s * 1000);
+    double rate = (double)g_http_pp.measured / s;
+
+    uint64_t* sorted = (uint64_t*)goc_malloc(sizeof(uint64_t) * g_http_pp.measured);
+    memcpy(sorted, g_http_pp.lat_ns, sizeof(uint64_t) * g_http_pp.measured);
+    qsort(sorted, g_http_pp.measured, sizeof(uint64_t), cmp_u64);
+
+    uint64_t sum_ns = 0;
+    for (size_t i = 0; i < g_http_pp.measured; i++)
+        sum_ns += g_http_pp.lat_ns[i];
+
+    double avg_us = ((double)sum_ns / (double)g_http_pp.measured) / 1000.0;
+    double p50_us = percentile_us(sorted, g_http_pp.measured, 50);
+    double p95_us = percentile_us(sorted, g_http_pp.measured, 95);
+    double p99_us = percentile_us(sorted, g_http_pp.measured, 99);
+
+    printf("HTTP ping-pong: %zu round trips in %dms (%.0f round trips/s, avg %.1fus p50 %.1fus p95 %.1fus p99 %.1fus, warmup %zu)\n",
+           g_http_pp.measured, ms, rate, avg_us, p50_us, p95_us, p99_us,
+           g_http_pp.warmup);
+    bench_print_stats();
+}
+
+
+/* =========================================================================
+ * 7. HTTP server throughput benchmark
+ * =========================================================================
+ *
+ * One HTTP/1.1 loopback server serves GET /plaintext with a fixed tiny body
+ * "OK".  `concurrency` client fibers issue back-to-back keep-alive GETs
+ * using a shared request shape, and we measure successful responses over a
+ * fixed measurement window after a warmup phase.
+ */
+
+#define HTTP_TP_PORT 19100
+#define HTTP_TP_URL  "http://127.0.0.1:19100/plaintext"
+
+static void http_tp_handler(goc_http_ctx_t* ctx) {
+    goc_take(goc_http_server_respond(ctx, 200, "text/plain", "OK"));
+}
+
+typedef struct {
+    uint64_t warmup_end_ns;
+    uint64_t measure_end_ns;
+    uint64_t* succ_out;
+    uint64_t* err_out;
+} http_tp_worker_args_t;
+
+static void http_tp_worker(void* arg) {
+    http_tp_worker_args_t* a = (http_tp_worker_args_t*)arg;
+    uint64_t succ = 0;
+    uint64_t err  = 0;
+
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    opts->timeout_ms = 1000;
+
+    for (;;) {
+        if (uv_hrtime() >= a->measure_end_ns)
+            break;
+
+        goc_http_response_t* r =
+            (goc_http_response_t*)goc_take(goc_http_get(HTTP_TP_URL, opts))->val;
+        uint64_t done_ns = uv_hrtime();
+
+        if (done_ns >= a->warmup_end_ns && done_ns < a->measure_end_ns) {
+            if (r && r->status == 200)
+                succ++;
+            else
+                err++;
+        }
+    }
+
+    *a->succ_out = succ;
+    *a->err_out  = err;
+}
+
+static void bench_http_server_throughput(size_t concurrency,
+                                         int warmup_ms,
+                                         int measure_ms) {
+    if (concurrency == 0 || warmup_ms < 0 || measure_ms <= 0)
+        return;
+
+    goc_http_server_t* srv = goc_http_server_make(goc_http_server_opts());
+    goc_http_server_route(srv, "GET", "/plaintext", http_tp_handler);
+    goc_take(goc_http_server_listen(srv, "127.0.0.1", HTTP_TP_PORT));
+
+    uint64_t start_ns      = uv_hrtime();
+    uint64_t warmup_end_ns = start_ns + (uint64_t)warmup_ms * 1000000ull;
+    uint64_t measure_end_ns = warmup_end_ns + (uint64_t)measure_ms * 1000000ull;
+
+    uint64_t* succ = (uint64_t*)goc_malloc(sizeof(uint64_t) * concurrency);
+    uint64_t* err  = (uint64_t*)goc_malloc(sizeof(uint64_t) * concurrency);
+    goc_chan** joins = (goc_chan**)goc_malloc(sizeof(goc_chan*) * concurrency);
+    http_tp_worker_args_t* args =
+        (http_tp_worker_args_t*)goc_malloc(sizeof(http_tp_worker_args_t) * concurrency);
+
+    for (size_t i = 0; i < concurrency; i++) {
+        succ[i] = 0;
+        err[i]  = 0;
+        args[i].warmup_end_ns  = warmup_end_ns;
+        args[i].measure_end_ns = measure_end_ns;
+        args[i].succ_out       = &succ[i];
+        args[i].err_out        = &err[i];
+        joins[i] = goc_go(http_tp_worker, &args[i]);
+    }
+
+    goc_take_all(joins, concurrency);
+    goc_take(goc_http_server_close(srv));
+
+    uint64_t total_succ = 0;
+    uint64_t total_err  = 0;
+    for (size_t i = 0; i < concurrency; i++) {
+        total_succ += succ[i];
+        total_err  += err[i];
+    }
+
+    double s = (double)measure_ms / 1000.0;
+    double rate = (double)total_succ / s;
+    printf("HTTP server throughput: %" PRIu64 " requests in %dms (%.0f req/s, %" PRIu64 " errors, concurrency %zu, warmup %dms)\n",
+           total_succ, measure_ms, rate, total_err, concurrency, warmup_ms);
+    bench_print_stats();
+}
+
+
+/* =========================================================================
  * main
  * =========================================================================
  */
@@ -576,12 +863,28 @@ static void main_fiber(void* _) {
     size_t select_tasks   = 200000;
     size_t spawn_count    = 200000;
     size_t prime_max      = 20000;
+    /* Lower count than CSP benchmarks: each HTTP request opens a new TCP
+     * connection.  See bench_http_ping_pong comment for context. */
+    size_t http_rounds    = 2000;
+    size_t http_tp_concurrency = 32;
+    int http_tp_warmup_ms = 1000;
+    int http_tp_measure_ms = 5000;
 
-    bench_ping_pong(ping_rounds);
-    bench_ring(ring_nodes, ring_hops);
-    bench_fan_in(select_workers, select_tasks);
-    bench_spawn_idle(spawn_count);
-    bench_prime_sieve(prime_max);
+    const char* http_only = getenv("GOC_BENCH_HTTP_ONLY");
+    int run_http_only = (http_only && http_only[0] == '1');
+
+    if (!run_http_only) {
+        bench_ping_pong(ping_rounds);
+        bench_ring(ring_nodes, ring_hops);
+        bench_fan_in(select_workers, select_tasks);
+        bench_spawn_idle(spawn_count);
+        bench_prime_sieve(prime_max);
+    }
+
+    bench_http_ping_pong(http_rounds);
+    bench_http_server_throughput(http_tp_concurrency,
+                                 http_tp_warmup_ms,
+                                 http_tp_measure_ms);
 }
 
 int main(void) {

--- a/bench/run-all.sh
+++ b/bench/run-all.sh
@@ -1,0 +1,59 @@
+#! /usr/bin/sh
+
+set -eu
+
+script_dir=$(
+    CDPATH= cd -- "$(dirname -- "$0")" && pwd
+)
+cd "$script_dir"
+
+run_checked() {
+	log_file=$1
+	shift
+
+	pipe_dir=$(mktemp -d)
+	pipe_path=$pipe_dir/out
+	mkfifo "$pipe_path"
+	tee -a "$log_file" <"$pipe_path" &
+	tee_pid=$!
+
+	if "$@" >"$pipe_path" 2>&1; then
+		cmd_status=0
+	else
+		cmd_status=$?
+	fi
+
+	wait "$tee_pid"
+	rm -f "$pipe_path"
+	rmdir "$pipe_dir"
+
+	if [ "$cmd_status" -ne 0 ]; then
+		exit "$cmd_status"
+	fi
+}
+
+find logs -type f -name '*.log' -exec truncate -s 0 {} +
+
+i=0
+while [ "$i" -lt 3 ]; do
+	run_checked logs/go.log make -C go run-all
+	i=$((i + 1))
+done
+
+i=0
+while [ "$i" -lt 3 ]; do
+	run_checked logs/clojure.log make -C clojure run-all
+	i=$((i + 1))
+done
+
+i=0
+while [ "$i" -lt 3 ]; do
+	run_checked logs/canary.log make -C libgoc build run-all
+	i=$((i + 1))
+done
+
+i=0
+while [ "$i" -lt 3 ]; do
+	run_checked logs/vmem.log make -C libgoc LIBGOC_VMEM=ON BUILD_DIR=../../build-bench-vmem build run-all
+	i=$((i + 1))
+done

--- a/include/goc.h
+++ b/include/goc.h
@@ -196,7 +196,30 @@ char* goc_sprintf(const char* fmt, ...);
 bool goc_in_fiber(void);
 
 /**
- * goc_go() — Spawn a fiber on the default thread pool.
+ * goc_current_pool() — Return the current fiber's pool, or NULL outside fibers.
+ */
+goc_pool* goc_current_pool(void);
+
+/**
+ * goc_current_or_default_pool() — Return current pool when in a fiber,
+ * otherwise return goc_default_pool().
+ */
+goc_pool* goc_current_or_default_pool(void);
+
+/**
+ * goc_current_thread() — Return the current OS thread id (libuv thread type).
+ */
+uv_thread_t goc_current_thread(void);
+
+/**
+ * goc_current_fiber() — Return the currently running fiber handle, or NULL
+ * outside fibers. The returned pointer is runtime-internal and opaque.
+ */
+void* goc_current_fiber(void);
+
+/**
+ * goc_go() — Spawn a fiber on the current pool when in fiber context,
+ * otherwise on the default thread pool.
  *
  * fn    : fiber entry point; receives arg.
  * arg   : arbitrary user data passed to fn.

--- a/include/goc_http.h
+++ b/include/goc_http.h
@@ -134,12 +134,24 @@ typedef struct {
  * Obtain a heap-allocated zero-initialised default with
  * goc_http_request_opts(); set only the fields you need. */
 typedef struct {
+    /* Pool to run the outbound client fiber on.
+     * Default (NULL): goc_current_or_default_pool(). */
+    goc_pool* pool;
+
     /* Extra headers to send with the request.
      * goc_array of goc_http_header_t*.  Default (NULL): none. */
     goc_array* headers;
 
     /* Request timeout in milliseconds.  0 = no timeout. */
     uint64_t timeout_ms;
+
+    /* Enable HTTP/1.1 keep-alive and connection reuse.
+     * 0 = disabled (default), non-zero = enabled.
+     *
+     * When enabled, goc_http may reuse an existing connection to the same
+     * host:port for subsequent requests on the same worker thread.
+     */
+    int keep_alive;
 } goc_http_request_opts_t;
 
 /* =========================================================================
@@ -183,6 +195,7 @@ goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int p
  * goc_http_server_close — gracefully stop the server.
  *
  * Stops accepting new connections and drains in-flight requests.
+ * Waits for all active connections to close before completing shutdown.
  * Returns a channel delivering goc_box_int(0) when shutdown is complete.
  */
 goc_chan* goc_http_server_close(goc_http_server_t* srv);
@@ -266,7 +279,8 @@ goc_chan* goc_http_server_respond_error(goc_http_ctx_t* ctx, int status,
 
 /**
  * goc_http_request_opts — allocate and return a default request options
- * struct.  Zero-initialised: no extra headers, no timeout.
+ * struct.  Zero-initialised: no extra headers, no timeout,
+ * keep-alive disabled, and pool set to goc_current_or_default_pool().
  */
 goc_http_request_opts_t* goc_http_request_opts(void);
 

--- a/include/goc_stats.h
+++ b/include/goc_stats.h
@@ -57,16 +57,16 @@ typedef struct goc_stats_event {
     goc_stats_event_type_t type;
     uint64_t timestamp;
     union {
-        struct { void* id; int status; int thread_count; } pool;
+        struct { int id; int status; int thread_count; } pool;
         struct {
             int      id;
-            void*    pool_id;
+            int      pool_id;
             int      status;
             int      pending_jobs;
             uint64_t steal_attempts;   /* lifetime steal attempts (only meaningful at STOPPED) */
             uint64_t steal_successes;  /* lifetime steal successes (only meaningful at STOPPED) */
         } worker;
-        struct { int id; int last_worker_id; int status; } fiber;
+        struct { int id; int last_worker_id; int last_pool_id; int status; } fiber;
         struct {
             int      id;
             int      status;
@@ -114,10 +114,10 @@ void goc_stats_flush(void);
  * ---------------------------------------------------------------------- */
 
 #ifdef GOC_ENABLE_STATS
-void goc_stats_submit_event_pool(void* id, int status, int thread_count);
-void goc_stats_submit_event_worker(int id, void* pool_id, int status, int pending_jobs,
+void goc_stats_submit_event_pool(int id, int status, int thread_count);
+void goc_stats_submit_event_worker(int id, int pool_id, int status, int pending_jobs,
                                    uint64_t steal_attempts, uint64_t steal_successes);
-void goc_stats_submit_event_fiber(int id, int last_worker_id, int status);
+void goc_stats_submit_event_fiber(int id, int last_worker_id, int last_pool_id, int status);
 void goc_stats_submit_event_channel(int id, int status, int buf_size, int item_count,
                                     uint64_t taker_scans, uint64_t putter_scans,
                                     uint64_t compaction_runs, uint64_t entries_removed);
@@ -152,14 +152,14 @@ void   goc_pool_get_steal_stats(uint64_t *attempts, uint64_t *successes,
     goc_stats_submit_event_pool((id), (status), (thread_count))
 #  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs, steal_att, steal_suc) \
     goc_stats_submit_event_worker((id), (pool_id), (status), (pending_jobs), (steal_att), (steal_suc))
-#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status) \
-    goc_stats_submit_event_fiber((id), (last_worker_id), (status))
+#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, last_pool_id, status) \
+    goc_stats_submit_event_fiber((id), (last_worker_id), (last_pool_id), (status))
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count, ts, ps, cr, er) \
     goc_stats_submit_event_channel((id), (status), (buf_size), (item_count), (ts), (ps), (cr), (er))
 #else
 #  define GOC_STATS_POOL_STATUS(id, status, thread_count)                            ((void)0)
 #  define GOC_STATS_WORKER_STATUS(id, pool_id, status, pending_jobs, steal_att, suc) ((void)0)
-#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, status)                         ((void)0)
+#  define GOC_STATS_FIBER_STATUS(id, last_worker_id, last_pool_id, status)           ((void)0)
 #  define GOC_STATS_CHANNEL_STATUS(id, status, buf_size, item_count, ts, ps, cr, er) ((void)0)
 #endif
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -165,6 +165,9 @@ void compact_dead_entries(goc_chan* ch)
     while (*pp) {
         goc_entry* e = *pp;
         if (atomic_load_explicit(&e->cancelled, memory_order_acquire)) {
+            GOC_DBG("compact_dead_entries: unlinking taker e=%p ch=%p kind=%d coro=%p\n",
+                    (void*)e, (void*)ch, (int)e->kind,
+                    (e->kind == GOC_FIBER ? (void*)e->coro : NULL));
             *pp = e->next;   /* unlink */
 #ifdef GOC_ENABLE_STATS
             removed++;
@@ -253,6 +256,12 @@ void chan_set_on_close(goc_chan* ch, void (*on_close)(void*), void* ud)
  * Idempotent. CAS on close_guard ensures exactly one caller proceeds.
  * Does NOT destroy the mutex — ownership transfers to goc_shutdown (gc.c).
  * -------------------------------------------------------------------------- */
+
+int goc_chan_is_closing(goc_chan* ch)
+{
+    return atomic_load_explicit(&ch->close_guard, memory_order_acquire);
+}
+
 void goc_close(goc_chan* ch)
 {
     void (*on_close)(void*) = NULL;
@@ -430,6 +439,8 @@ goc_val_t* goc_take(goc_chan* ch)
     GOC_DBG("goc_take: parking coro=%p on ch=%p\n", (void*)mco_running(), (void*)ch);
 
     /* Append to takers list */
+    GOC_DBG("takers_append: ch=%p e=%p kind=%d coro=%p\n",
+            (void*)ch, (void*)e, (int)e->kind, (void*)e->coro);
     chan_list_append(&ch->takers, &ch->takers_tail, e);
 
     /* Set parked = 0 on the fiber's initial entry while ch->lock is still held.
@@ -574,6 +585,8 @@ goc_val_t* goc_take_sync(goc_chan* ch)
     goc_sync_init(&e.sync_obj);
     e.sync_sem_ptr = &e.sync_obj;
 
+    GOC_DBG("takers_append: ch=%p e=%p kind=%d coro=%p\n",
+            (void*)ch, (void*)&e, (int)e.kind, NULL);
     chan_list_append(&ch->takers, &ch->takers_tail, &e);
 
     uv_mutex_unlock(ch->lock);

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -31,6 +31,27 @@ bool goc_in_fiber(void) {
     return mco_running() != NULL;
 }
 
+goc_pool* goc_current_pool(void) {
+    mco_coro* co = mco_running();
+    if (!co)
+        return NULL;
+    goc_entry* entry = (goc_entry*)mco_get_user_data(co);
+    return entry ? entry->pool : NULL;
+}
+
+goc_pool* goc_current_or_default_pool(void) {
+    goc_pool* pool = goc_current_pool();
+    return pool ? pool : g_default_pool;
+}
+
+uv_thread_t goc_current_thread(void) {
+    return uv_thread_self();
+}
+
+void* goc_current_fiber(void) {
+    return (void*)mco_running();
+}
+
 /* ---------------------------------------------------------------------------
  * fiber_trampoline
  *
@@ -43,7 +64,7 @@ static void fiber_trampoline(mco_coro* co) {
     goc_entry* entry = (goc_entry*)mco_get_user_data(co);
     entry->fn(entry->fn_arg);
     /* Telemetry: fiber finished */
-    GOC_STATS_FIBER_STATUS(entry->id, 0, GOC_FIBER_COMPLETED);
+    GOC_STATS_FIBER_STATUS(entry->id, 0, goc_pool_id(entry->pool), GOC_FIBER_COMPLETED);
     goc_close(entry->join_ch);
 }
 
@@ -84,6 +105,10 @@ goc_entry* goc_fiber_entry_create(goc_pool* pool,
      *    Unregistered in pool.c before mco_destroy when the fiber reaches
      *    MCO_DEAD. */
     void* fiber_stack_top    = (char*)entry->coro->stack_base + entry->coro->stack_size;
+    GOC_DBG("fiber_create: entry=%p coro=%p stack_base=%p stack_top=%p stack_size=%zu\n",
+            (void*)entry, (void*)entry->coro,
+            (void*)entry->coro->stack_base, fiber_stack_top,
+            entry->coro->stack_size);
     entry->fiber_root_handle = goc_fiber_root_register(entry->coro, fiber_stack_top, entry);
 
     /* 6. Record the canary pointer (lowest word of the fiber stack). */
@@ -93,7 +118,7 @@ goc_entry* goc_fiber_entry_create(goc_pool* pool,
     goc_stack_canary_set(entry->stack_canary_ptr);
 
     /* Telemetry: fiber created; -1 = not yet scheduled on any worker */
-    GOC_STATS_FIBER_STATUS(entry->id, -1, GOC_FIBER_CREATED);
+    GOC_STATS_FIBER_STATUS(entry->id, -1, goc_pool_id(entry->pool), GOC_FIBER_CREATED);
 
     return entry;
 }
@@ -120,7 +145,7 @@ goc_chan* goc_go_on(goc_pool* pool, void (*fn)(void*), void* arg) {
  * --------------------------------------------------------------------------- */
 
 goc_chan* goc_go(void (*fn)(void*), void* arg) {
-    return goc_go_on(g_default_pool, fn, arg);
+    return goc_go_on(goc_current_or_default_pool(), fn, arg);
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/gc.c
+++ b/src/gc.c
@@ -588,9 +588,12 @@ void goc_init(void) {
 
 void goc_shutdown(void) {
     lifecycle_abort_non_main_thread("goc_shutdown");
+    GOC_DBG("goc_shutdown: begin\n");
 
     /* B.1 — Drain and destroy all registered pools (including g_default_pool). */
+    GOC_DBG("goc_shutdown: B.1 pool_registry_destroy_all begin\n");
     pool_registry_destroy_all();
+    GOC_DBG("goc_shutdown: B.1 pool_registry_destroy_all done\n");
 
     /* B.2 — Destroy channel mutexes and tear down the live-channels registry.
      *
@@ -610,21 +613,27 @@ void goc_shutdown(void) {
     live_channels_cap = 0;
 
     uv_mutex_destroy(&g_live_mutex);
+    GOC_DBG("goc_shutdown: B.2 channels/mutex teardown done\n");
 
     /* B.2.1 — Destroy all RW mutex internal locks. */
+    GOC_DBG("goc_shutdown: B.2.1 mutex_registry_destroy_all begin\n");
     mutex_registry_destroy_all();
+    GOC_DBG("goc_shutdown: B.2.1 mutex_registry_destroy_all done\n");
 
     /* B.3 — Shut down the event loop and join the loop thread.
      *
      * Keep g_live_uv_mutex alive until loop shutdown completes: close
      * callbacks that run on the loop thread call gc_handle_unregister(). */
+    GOC_DBG("goc_shutdown: B.3 loop_shutdown begin\n");
     loop_shutdown();
+    GOC_DBG("goc_shutdown: B.3 loop_shutdown done\n");
 
     /* B.3a — Tear down the live UV handle roots registry. */
     live_uv_handles     = NULL;
     live_uv_handles_len = 0;
     live_uv_handles_cap = 0;
     uv_mutex_destroy(&g_live_uv_mutex);
+    GOC_DBG("goc_shutdown: B.3a live_uv teardown done\n");
 
     /* B.4 — Free all fiber root chunks accumulated during this lifecycle.
      *
@@ -643,4 +652,5 @@ void goc_shutdown(void) {
         atomic_store_explicit(&fiber_root_bitmap[w], 0, memory_order_relaxed);
     atomic_store_explicit(&fiber_root_num_chunks, 0, memory_order_relaxed);
     uv_mutex_destroy(&fiber_root_mutex);
+    GOC_DBG("goc_shutdown: B.4 fiber roots teardown done; shutdown complete\n");
 }

--- a/src/goc_http.c
+++ b/src/goc_http.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <assert.h>
+#include <stdatomic.h>
 #include "../vendor/picohttpparser/picohttpparser.h"
 #include "../include/goc_http.h"
 #include "../include/goc_io.h"
@@ -51,14 +52,6 @@ static void close_on_put(goc_status_t ok, void* ud)
     GOC_DBG("close_on_put(http): closing ch=%p ok=%d\n", ud, (int)ok);
     goc_close((goc_chan*)ud);
     GOC_DBG("close_on_put(http): done ch=%p\n", ud);
-}
-
-static char* goc_strdup(const char* s)
-{
-    size_t n = strlen(s);
-    char*  d = (char*)goc_malloc(n + 1);
-    memcpy(d, s, n + 1);
-    return d;
 }
 
 /* =========================================================================
@@ -80,6 +73,7 @@ typedef struct {
     uv_tcp_t*          conn;   /* GC-registered per-connection handle */
     struct goc_http_server* srv;
     goc_http_handler_t handler;
+    int                keep_alive;
     goc_http_ctx_t     ctx;    /* MUST be last */
 } goc_req_wrapper_t;
 
@@ -90,6 +84,10 @@ typedef struct {
 struct goc_http_server {
     uv_tcp_t*    tcp;          /* GC-allocated TCP listen handle */
     goc_chan*    accept_ch;    /* from goc_io_tcp_server_make */
+    goc_chan*    close_ch;     /* broadcast shutdown to live connection fibers */
+
+    _Atomic int  active_conns; /* count of in-flight connection fibers */
+    goc_chan*    shutdown_ch;  /* closed when active_conns drains to 0 */
 
     goc_route_t* routes;
     size_t       n_routes;
@@ -98,6 +96,90 @@ struct goc_http_server {
     goc_pool*    pool;
     goc_array*   middleware;
 };
+
+/* Per-worker-thread HTTP keep-alive slot for outbound client requests.
+ *
+ * This is intentionally tiny (one reusable connection per thread) to keep the
+ * implementation simple and lock-free while still removing most connect/setup
+ * overhead for common repeated calls to the same host:port.
+ */
+#if defined(_MSC_VER)
+#  define GOC_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define GOC_THREAD_LOCAL _Thread_local
+#else
+#  define GOC_THREAD_LOCAL __thread
+#endif
+
+typedef struct {
+    uv_tcp_t* tcp;
+    char*     host;
+    uint16_t  port;
+    int       in_use;
+} goc_http_keepalive_slot_t;
+
+static GOC_THREAD_LOCAL goc_http_keepalive_slot_t g_http_ka_slot = {0};
+static _Atomic uint64_t g_http_client_req_seq = 0;
+static _Atomic int g_http_non_keepalive_inflight = 0;
+
+#define GOC_HTTP_NON_KEEPALIVE_MAX 64
+
+static void http_client_non_keepalive_acquire(void)
+{
+    for (;;) {
+        /* During shutdown, skip the throttle so fibers reach the fast-fail
+         * DNS/connect path and exit promptly instead of spinning on 1ms
+         * timeouts and stalling pool drain. */
+        if (goc_loop_is_shutting_down())
+            return;
+        int cur = atomic_load_explicit(&g_http_non_keepalive_inflight,
+                                       memory_order_relaxed);
+        while (cur < GOC_HTTP_NON_KEEPALIVE_MAX) {
+            if (atomic_compare_exchange_weak_explicit(
+                    &g_http_non_keepalive_inflight,
+                    &cur,
+                    cur + 1,
+                    memory_order_acq_rel,
+                    memory_order_relaxed)) {
+                return;
+            }
+        }
+        goc_take(goc_timeout(1));
+    }
+}
+
+static void http_client_non_keepalive_release(void)
+{
+    int prev = atomic_fetch_sub_explicit(&g_http_non_keepalive_inflight,
+                                         1,
+                                         memory_order_acq_rel);
+    if (prev <= 0)
+        atomic_store_explicit(&g_http_non_keepalive_inflight,
+                              0,
+                              memory_order_release);
+}
+
+static int keepalive_slot_matches(const goc_http_keepalive_slot_t* s,
+                                  const char* host, uint16_t port)
+{
+    return s && s->tcp && s->host && s->port == port && strcmp(s->host, host) == 0;
+}
+
+static void keepalive_slot_drop(goc_http_keepalive_slot_t* s)
+{
+    if (!s)
+        return;
+    GOC_DBG("keepalive_slot_drop: slot=%p tcp=%p host=%s port=%u in_use=%d\n",
+            (void*)s, (void*)s->tcp, s->host ? s->host : "<null>",
+            (unsigned)s->port, s->in_use);
+    if (s->tcp) {
+        goc_io_handle_close((uv_handle_t*)s->tcp, NULL);
+        s->tcp = NULL;
+    }
+    s->host  = NULL;
+    s->port  = 0;
+    s->in_use = 0;
+}
 
 /* =========================================================================
  * Forward declarations
@@ -145,6 +227,7 @@ goc_http_server_opts_t* goc_http_server_opts(void)
     goc_http_server_opts_t* o =
         (goc_http_server_opts_t*)goc_malloc(sizeof(goc_http_server_opts_t));
     memset(o, 0, sizeof(*o));
+    o->pool = goc_current_or_default_pool();
     return o;
 }
 
@@ -154,8 +237,11 @@ goc_http_server_t* goc_http_server_make(const goc_http_server_opts_t* opts)
         (goc_http_server_t*)goc_malloc(sizeof(goc_http_server_t));
     memset(srv, 0, sizeof(*srv));
 
-    srv->pool       = opts && opts->pool ? opts->pool : NULL;
+    srv->pool       = opts && opts->pool ? opts->pool : goc_current_or_default_pool();
     srv->middleware = opts ? opts->middleware : NULL;
+    srv->close_ch   = goc_chan_make(0);
+    srv->active_conns = 0;
+    srv->shutdown_ch  = goc_chan_make(0);
 
     srv->cap_routes = 8;
     srv->routes     =
@@ -175,7 +261,8 @@ goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int p
     if (r < 0)
         r = uv_ip6_addr(host, port, (struct sockaddr_in6*)&addr);
     if (r < 0) {
-        goc_put_cb(ready_ch, goc_box_int(r), close_on_put, ready_ch);
+        goc_put(ready_ch, goc_box_int(r));
+        goc_close(ready_ch);
         return ready_ch;
     }
 
@@ -187,7 +274,8 @@ goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int p
          * needed.  Null the pointer so the server struct is not left with a
          * stale reference to the unused allocation. */
         srv->tcp = NULL;
-        goc_put_cb(ready_ch, goc_box_int(r), close_on_put, ready_ch);
+        goc_put(ready_ch, goc_box_int(r));
+        goc_close(ready_ch);
         return ready_ch;
     }
 
@@ -198,7 +286,8 @@ goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int p
     if (r < 0) {
         goc_io_handle_close((uv_handle_t*)srv->tcp, NULL);
         srv->tcp = NULL;
-        goc_put_cb(ready_ch, goc_box_int(r), close_on_put, ready_ch);
+        goc_put(ready_ch, goc_box_int(r));
+        goc_close(ready_ch);
         return ready_ch;
     }
 
@@ -210,7 +299,7 @@ goc_chan* goc_http_server_listen(goc_http_server_t* srv, const char* host, int p
     gc_handle_register(srv);
 
     /* Spawn the accept loop fiber. */
-    goc_pool* pool = srv->pool ? srv->pool : goc_default_pool();
+    goc_pool* pool = srv->pool ? srv->pool : goc_current_or_default_pool();
     goc_go_on(pool, accept_loop_fiber, srv);
 
     return ready_ch;
@@ -220,7 +309,16 @@ goc_chan* goc_http_server_close(goc_http_server_t* srv)
 {
     goc_chan* ch = goc_chan_make(1);
 
+    GOC_DBG("goc_http_server_close: srv=%p tcp=%p accept_ch=%p close_ch=%p\n",
+            (void*)srv, (void*)srv->tcp, (void*)srv->accept_ch, (void*)srv->close_ch);
+
+    if (srv->close_ch) {
+        goc_close(srv->close_ch);
+        srv->close_ch = NULL;
+    }
+
     /* Close the accept channel so the accept loop fiber breaks. */
+    int was_listening = (srv->accept_ch != NULL);
     if (srv->accept_ch) {
         goc_close(srv->accept_ch);
         srv->accept_ch = NULL;
@@ -232,10 +330,24 @@ goc_chan* goc_http_server_close(goc_http_server_t* srv)
         srv->tcp = NULL;
     }
 
+    /* Wait for all in-flight connection fibers (and accept_loop_fiber) to
+     * finish.  accept_loop_fiber counts itself in active_conns, so if listen
+     * was ever called active_conns is guaranteed > 0 until the accept loop
+     * exits — we can unconditionally goc_take.  If listen was never called
+     * nobody will close shutdown_ch, so we close it ourselves. */
+    if (was_listening)
+        goc_take(srv->shutdown_ch);
+    else
+        goc_close(srv->shutdown_ch);
+    srv->shutdown_ch = NULL;
+
     /* Unpin the server from the GC root list. */
     gc_handle_unregister(srv);
 
-    goc_put_cb(ch, goc_box_int(0), close_on_put, ch);
+    GOC_DBG("goc_http_server_close: completed srv=%p tcp=%p accept_ch=%p close_ch=%p\n",
+            (void*)srv, (void*)srv->tcp, (void*)srv->accept_ch, (void*)srv->close_ch);
+    goc_put(ch, goc_box_int(0));
+    goc_close(ch);
     return ch;
 }
 
@@ -280,6 +392,27 @@ static int route_match(const char* method, const char* path,
            (path[plen] == '/' || path[plen] == '\0');
 }
 
+static int request_wants_keepalive(const struct phr_header* headers,
+                                   size_t num_headers,
+                                   int minor_version)
+{
+    /* HTTP/1.1 default keep-alive unless Connection: close.
+     * HTTP/1.0 default close unless Connection: keep-alive. */
+    int default_keep = (minor_version >= 1);
+    for (size_t i = 0; i < num_headers; i++) {
+        if (headers[i].name_len == 10 &&
+            strncasecmp(headers[i].name, "connection", 10) == 0) {
+            if (headers[i].value_len == 5 &&
+                strncasecmp(headers[i].value, "close", 5) == 0)
+                return 0;
+            if (headers[i].value_len == 10 &&
+                strncasecmp(headers[i].value, "keep-alive", 10) == 0)
+                return 1;
+        }
+    }
+    return default_keep;
+}
+
 /* =========================================================================
  * 3. Accept loop and per-connection fibers
  * ====================================================================== */
@@ -287,14 +420,25 @@ static int route_match(const char* method, const char* path,
 typedef struct {
     goc_http_server_t* srv;
     uv_tcp_t*     conn;
+    goc_chan*     close_ch; /* captured at spawn; srv->close_ch may be NULL by the time the fiber runs */
 } conn_arg_t;
 
 static void accept_loop_fiber(void* arg)
 {
     goc_http_server_t* srv      = (goc_http_server_t*)arg;
     goc_chan*     accept_ch = srv->accept_ch; /* cache before any yield point */
+    goc_chan*     close_ch  = srv->close_ch;  /* cache before any yield point */
     GOC_DBG("accept_loop_fiber: started, accept_ch=%p\n", (void*)accept_ch);
-    if (!accept_ch) { GOC_DBG("accept_loop_fiber: accept_ch is NULL, returning\n"); return; } /* server closed before fiber started */
+    if (!accept_ch) {
+        GOC_DBG("accept_loop_fiber: accept_ch is NULL, closing shutdown_ch and returning\n");
+        goc_close(srv->shutdown_ch); /* active_conns was never incremented; we are the only closer */
+        return;
+    }
+    /* Count this fiber itself so active_conns > 0 until we finish all spawns.
+     * This prevents goc_http_server_close from declaring the drain complete
+     * before we have finished incrementing for connections we are about to
+     * spawn. */
+    atomic_fetch_add_explicit(&srv->active_conns, 1, memory_order_release);
     for (;;) {
         GOC_DBG("accept_loop_fiber: waiting for connection on accept_ch=%p\n", (void*)accept_ch);
         goc_val_t* v = goc_take(accept_ch);
@@ -303,13 +447,32 @@ static void accept_loop_fiber(void* arg)
             break;  /* channel closed — server is shutting down */
         uv_tcp_t* conn = (uv_tcp_t*)v->val;
         conn_arg_t* a  = (conn_arg_t*)goc_malloc(sizeof(conn_arg_t));
-        a->srv  = srv;
-        a->conn = conn;
+        a->srv      = srv;
+        a->conn     = conn;
+        a->close_ch = close_ch;
         GOC_DBG("accept_loop_fiber: spawning handle_conn_fiber for conn=%p\n", (void*)conn);
-        goc_pool* pool = srv->pool ? srv->pool : goc_default_pool();
+        atomic_fetch_add_explicit(&srv->active_conns, 1, memory_order_release);
+        goc_pool* pool = srv->pool ? srv->pool : goc_current_or_default_pool();
         goc_go_on(pool, handle_conn_fiber, a);
     }
+
+    /* Drain any connections buffered in accept_ch that were not yet spawned.
+     * on_server_connection calls uv_accept immediately, so these handles have
+     * a live server-side fd.  Close them now to send FIN to clients; without
+     * this, clients waiting on read hang indefinitely. */
+    for (;;) {
+        goc_val_t* v = goc_take(accept_ch);
+        if (!v || v->ok != GOC_OK)
+            break;
+        uv_tcp_t* conn = (uv_tcp_t*)v->val;
+        GOC_DBG("accept_loop_fiber: closing unspawned conn=%p\n", (void*)conn);
+        gc_handle_unregister(conn);
+        goc_io_handle_close((uv_handle_t*)conn, NULL);
+    }
+
     GOC_DBG("accept_loop_fiber: exiting (accept_ch closed)\n");
+    if (atomic_fetch_sub_explicit(&srv->active_conns, 1, memory_order_release) == 1)
+        goc_close(srv->shutdown_ch);
 }
 
 /* Maximum raw request size before we abort the connection. */
@@ -324,11 +487,11 @@ static void handle_conn_fiber(void* arg)
     conn_arg_t*   a    = (conn_arg_t*)arg;
     goc_http_server_t* srv  = a->srv;
     uv_tcp_t*     conn = a->conn;
+    goc_chan*     close_ch = a->close_ch;
     GOC_DBG("handle_conn_fiber: started conn=%p\n", (void*)conn);
 
     /* Accumulation buffer (plain-malloc; we control its entire lifetime). */
     size_t buf_cap = 4096;
-    size_t buf_len = 0;
     char*  buf     = (char*)malloc(buf_cap);
     if (!buf) {
         GOC_DBG("handle_conn_fiber: malloc failed, closing conn\n");
@@ -336,126 +499,162 @@ static void handle_conn_fiber(void* arg)
         return;
     }
 
-    GOC_DBG("handle_conn_fiber: calling goc_io_read_start on conn=%p\n", (void*)conn);
-    goc_chan* read_ch = goc_io_read_start((uv_stream_t*)conn);
-    GOC_DBG("handle_conn_fiber: goc_io_read_start returned read_ch=%p\n", (void*)read_ch);
+    for (;;) {
+        size_t buf_len = 0;
+        int read_started = 0;
+        int must_close_conn = 0;
 
-    /* ---- Read until we have a complete HTTP request head ---- */
-    const char*       method        = NULL;
-    size_t            method_len    = 0;
-    const char*       path          = NULL;
-    size_t            path_len      = 0;
-    int               minor_version = 0;
-    struct phr_header headers[GOC_SERVER_MAX_HDRS];
-    size_t            num_headers   = GOC_SERVER_MAX_HDRS;
-    int               pret          = -2;
+        GOC_DBG("handle_conn_fiber: calling goc_io_read_start on conn=%p\n", (void*)conn);
+        goc_chan* read_ch = goc_io_read_start((uv_stream_t*)conn);
+        read_started = 1;
+        GOC_DBG("handle_conn_fiber: goc_io_read_start returned read_ch=%p\n", (void*)read_ch);
 
-    while (pret == -2) {
-        GOC_DBG("handle_conn_fiber: waiting for head data on read_ch=%p buf_len=%zu\n", (void*)read_ch, buf_len);
-        goc_val_t* v = goc_take(read_ch);
-        GOC_DBG("handle_conn_fiber: head goc_take returned v=%p ok=%d\n", (void*)v, v ? (int)v->ok : -1);
-        if (!v || v->ok != GOC_OK)
-            goto cleanup;
-        goc_io_read_t* r = (goc_io_read_t*)v->val;
-        GOC_DBG("handle_conn_fiber: head chunk nread=%zd\n", r->nread);
-        if (r->nread < 0)
-            goto cleanup;  /* EOF or read error before full head */
+        /* ---- Read until we have a complete HTTP request head ---- */
+        const char*       method        = NULL;
+        size_t            method_len    = 0;
+        const char*       path          = NULL;
+        size_t            path_len      = 0;
+        int               minor_version = 0;
+        struct phr_header headers[GOC_SERVER_MAX_HDRS];
+        size_t            num_headers   = GOC_SERVER_MAX_HDRS;
+        int               pret          = -2;
 
-        size_t chunk = (size_t)r->nread;
-        if (buf_len + chunk > GOC_SERVER_MAX_REQ_SIZE)
-            goto stop_and_close;
-        if (buf_len + chunk > buf_cap) {
-            size_t nc = buf_cap;
-            while (nc < buf_len + chunk) nc *= 2;
-            char* nb = (char*)realloc(buf, nc);
-            if (!nb) goto stop_and_close;
-            buf = nb; buf_cap = nc;
-        }
-        memcpy(buf + buf_len, r->buf->base, chunk);
-        buf_len += chunk;
-
-        num_headers = GOC_SERVER_MAX_HDRS;
-        pret = phr_parse_request(buf, buf_len,
-                                  &method, &method_len,
-                                  &path,   &path_len,
-                                  &minor_version,
-                                  headers, &num_headers, 0);
-    }
-
-    if (pret < 0) {
-        /* HTTP parse error — send 400 Bad Request */
-        static const char resp400[] =
-            "HTTP/1.1 400 Bad Request\r\n"
-            "Content-Type: text/plain\r\nContent-Length: 11\r\n"
-            "Connection: close\r\n\r\nBad Request";
-        uv_buf_t b = uv_buf_init((char*)resp400, sizeof(resp400) - 1);
-        goc_take(goc_io_write((uv_stream_t*)conn, &b, 1));
-        goto stop_and_close;
-    }
-
-    {
-        /* ---- Find Content-Length and read remaining body bytes ---- */
-        ssize_t content_length = 0;
-        for (size_t i = 0; i < num_headers; i++) {
-            if (headers[i].name_len == 14 &&
-                strncasecmp(headers[i].name, "content-length", 14) == 0) {
-                char tmp[32];
-                size_t vl = headers[i].value_len < 31
-                            ? headers[i].value_len : 31;
-                memcpy(tmp, headers[i].value, vl);
-                tmp[vl] = '\0';
-                content_length = (ssize_t)atol(tmp);
+        while (pret == -2) {
+            GOC_DBG("handle_conn_fiber: entering goc_alts read_ch=%p close_ch=%p\n",
+                    (void*)read_ch, (void*)close_ch);
+            goc_alt_op_t ops[] = {
+                { .ch = read_ch,  .op_kind = GOC_ALT_TAKE, .put_val = NULL },
+                { .ch = close_ch, .op_kind = GOC_ALT_TAKE, .put_val = NULL },
+            };
+            goc_alts_result_t* sel = goc_alts(ops, 2);
+            if (!sel || sel->ch != read_ch || sel->value.ok != GOC_OK) {
+                must_close_conn = 1;
                 break;
             }
-        }
-
-        size_t head_consumed = (size_t)pret;
-        size_t body_end = head_consumed +
-                          (content_length > 0 ? (size_t)content_length : 0);
-
-        while (buf_len < body_end) {
-            GOC_DBG("handle_conn_fiber: waiting for body data buf_len=%zu body_end=%zu\n", buf_len, body_end);
-            goc_val_t* v = goc_take(read_ch);
-            GOC_DBG("handle_conn_fiber: body goc_take returned v=%p ok=%d\n", (void*)v, v ? (int)v->ok : -1);
-            if (!v || v->ok != GOC_OK) break;
+            goc_val_t* v = &sel->value;
             goc_io_read_t* r = (goc_io_read_t*)v->val;
-            GOC_DBG("handle_conn_fiber: body chunk nread=%zd\n", r->nread);
-            if (r->nread < 0) break;
+            if (r->nread < 0) {
+                must_close_conn = 1;
+                break;
+            }
 
             size_t chunk = (size_t)r->nread;
-            if (buf_len + chunk > GOC_SERVER_MAX_REQ_SIZE)
-                goto stop_and_close;
+            if (buf_len + chunk > GOC_SERVER_MAX_REQ_SIZE) {
+                must_close_conn = 1;
+                break;
+            }
             if (buf_len + chunk > buf_cap) {
                 size_t nc = buf_cap;
                 while (nc < buf_len + chunk) nc *= 2;
                 char* nb = (char*)realloc(buf, nc);
-                if (!nb) goto stop_and_close;
-                buf = nb; buf_cap = nc;
+                if (!nb) {
+                    must_close_conn = 1;
+                    break;
+                }
+                buf = nb;
+                buf_cap = nc;
             }
             memcpy(buf + buf_len, r->buf->base, chunk);
             buf_len += chunk;
+
+            num_headers = GOC_SERVER_MAX_HDRS;
+            pret = phr_parse_request(buf, buf_len,
+                                     &method, &method_len,
+                                     &path,   &path_len,
+                                     &minor_version,
+                                     headers, &num_headers, 0);
         }
 
-        /*
-         * Stop reading and drain the channel.  This ensures stream->data is
-         * NULL before goc_io_handle_close overwrites it with the close context.
-         */
-        GOC_DBG("handle_conn_fiber: calling goc_io_read_stop on conn=%p\n", (void*)conn);
-        goc_io_read_stop((uv_stream_t*)conn);
-        GOC_DBG("handle_conn_fiber: draining read_ch=%p\n", (void*)read_ch);
-        for (;;) {
-            goc_val_t* dv = goc_take(read_ch);
-            GOC_DBG("handle_conn_fiber: drain read_ch goc_take v=%p ok=%d\n", (void*)dv, dv ? (int)dv->ok : -1);
-            if (!dv || dv->ok != GOC_OK) break;
+        if (!must_close_conn && pret < 0) {
+            static const char resp400[] =
+                "HTTP/1.1 400 Bad Request\r\n"
+                "Content-Type: text/plain\r\nContent-Length: 11\r\n"
+                "Connection: close\r\n\r\nBad Request";
+            uv_buf_t b = uv_buf_init((char*)resp400, sizeof(resp400) - 1);
+            goc_take(goc_io_write((uv_stream_t*)conn, &b, 1));
+            must_close_conn = 1;
         }
-        GOC_DBG("handle_conn_fiber: drain complete\n");
+
+        int keep_alive_req = 0;
+        ssize_t content_length = 0;
+        size_t head_consumed = 0;
+        size_t body_end = 0;
+
+        if (!must_close_conn) {
+            for (size_t i = 0; i < num_headers; i++) {
+                if (headers[i].name_len == 14 &&
+                    strncasecmp(headers[i].name, "content-length", 14) == 0) {
+                    char tmp[32];
+                    size_t vl = headers[i].value_len < 31
+                                ? headers[i].value_len : 31;
+                    memcpy(tmp, headers[i].value, vl);
+                    tmp[vl] = '\0';
+                    content_length = (ssize_t)atol(tmp);
+                    break;
+                }
+            }
+
+            keep_alive_req = request_wants_keepalive(headers, num_headers, minor_version);
+            head_consumed = (size_t)pret;
+            body_end = head_consumed +
+                      (content_length > 0 ? (size_t)content_length : 0);
+
+            while (buf_len < body_end) {
+                goc_alt_op_t ops[] = {
+                    { .ch = read_ch,  .op_kind = GOC_ALT_TAKE, .put_val = NULL },
+                    { .ch = close_ch, .op_kind = GOC_ALT_TAKE, .put_val = NULL },
+                };
+                goc_alts_result_t* sel = goc_alts(ops, 2);
+                if (!sel || sel->ch != read_ch || sel->value.ok != GOC_OK) {
+                    must_close_conn = 1;
+                    break;
+                }
+                goc_val_t* v = &sel->value;
+                goc_io_read_t* r = (goc_io_read_t*)v->val;
+                if (r->nread < 0) {
+                    must_close_conn = 1;
+                    break;
+                }
+
+                size_t chunk = (size_t)r->nread;
+                if (buf_len + chunk > GOC_SERVER_MAX_REQ_SIZE) {
+                    must_close_conn = 1;
+                    break;
+                }
+                if (buf_len + chunk > buf_cap) {
+                    size_t nc = buf_cap;
+                    while (nc < buf_len + chunk) nc *= 2;
+                    char* nb = (char*)realloc(buf, nc);
+                    if (!nb) {
+                        must_close_conn = 1;
+                        break;
+                    }
+                    buf = nb;
+                    buf_cap = nc;
+                }
+                memcpy(buf + buf_len, r->buf->base, chunk);
+                buf_len += chunk;
+            }
+        }
+
+        if (read_started) {
+            goc_io_read_stop((uv_stream_t*)conn);
+            for (;;) {
+                goc_val_t* dv = goc_take(read_ch);
+                if (!dv || dv->ok != GOC_OK)
+                    break;
+            }
+            read_started = 0;
+        }
+
+        if (must_close_conn)
+            break;
 
         /* ---- Build GC-managed method/path/query strings ---- */
         char* method_str = (char*)goc_malloc(method_len + 1);
         memcpy(method_str, method, method_len);
         method_str[method_len] = '\0';
 
-        /* Split path from query string. */
         size_t      path_only_len = path_len;
         const char* q_start       = NULL;
         for (size_t i = 0; i < path_len; i++) {
@@ -476,32 +675,37 @@ static void handle_conn_fiber(void* arg)
             memcpy(query_str, q_start, query_len);
         query_str[query_len] = '\0';
 
-        /* ---- Route lookup ---- */
         goc_http_handler_t handler = NULL;
         for (size_t i = 0; i < srv->n_routes; i++) {
             if (route_match(method_str, path_str,
-                             srv->routes[i].method,
-                             srv->routes[i].pattern)) {
+                            srv->routes[i].method,
+                            srv->routes[i].pattern)) {
                 handler = srv->routes[i].handler;
                 break;
             }
         }
 
         if (!handler) {
-            GOC_DBG("handle_conn_fiber: no route for method=%s path=%s → 404\n", method_str, path_str);
-            static const char resp404[] =
-                "HTTP/1.1 404 Not Found\r\n"
-                "Content-Type: text/plain\r\nContent-Length: 10\r\n"
-                "Connection: close\r\n\r\nNot Found\n";
-            uv_buf_t b = uv_buf_init((char*)resp404, sizeof(resp404) - 1);
-            goc_take(goc_io_write((uv_stream_t*)conn, &b, 1));
-            free(buf);
-            goc_io_handle_close((uv_handle_t*)conn, NULL);
-            return;
+            const char* body404 = "Not Found\n";
+            char resp404[256];
+            int n = snprintf(resp404, sizeof(resp404),
+                             "HTTP/1.1 404 Not Found\r\n"
+                             "Content-Type: text/plain\r\n"
+                             "Content-Length: %zu\r\n"
+                             "Connection: %s\r\n\r\n"
+                             "%s",
+                             strlen(body404),
+                             keep_alive_req ? "keep-alive" : "close",
+                             body404);
+            if (n > 0) {
+                uv_buf_t b = uv_buf_init(resp404, (unsigned int)n);
+                goc_take(goc_io_write((uv_stream_t*)conn, &b, 1));
+            }
+            if (!keep_alive_req)
+                break;
+            continue;
         }
-        GOC_DBG("handle_conn_fiber: matched route for method=%s path=%s handler=%p\n", method_str, path_str, (void*)(uintptr_t)handler);
 
-        /* ---- Build GC-managed headers array ---- */
         goc_array* req_headers = goc_array_make(num_headers);
         for (size_t i = 0; i < num_headers; i++) {
             goc_http_header_t* hdr =
@@ -517,7 +721,6 @@ static void handle_conn_fiber(void* arg)
             goc_array_push(req_headers, hdr);
         }
 
-        /* ---- Build GC-managed body array (one element per byte) ---- */
         size_t body_offset  = head_consumed;
         size_t act_body_len = (content_length > 0 && buf_len > body_offset)
                               ? buf_len - body_offset : 0;
@@ -527,16 +730,14 @@ static void handle_conn_fiber(void* arg)
         goc_array* body_arr = goc_array_make(act_body_len);
         for (size_t i = 0; i < act_body_len; i++)
             goc_array_push(body_arr,
-                goc_box_int((unsigned char)buf[body_offset + i]));
+                           goc_box_int((unsigned char)buf[body_offset + i]));
 
-        free(buf); buf = NULL;
-
-        /* ---- Build the per-request wrapper ---- */
         goc_req_wrapper_t* w =
             (goc_req_wrapper_t*)goc_malloc(sizeof(goc_req_wrapper_t));
         w->conn          = conn;
         w->srv           = srv;
         w->handler       = handler;
+        w->keep_alive    = keep_alive_req;
         w->ctx.method    = method_str;
         w->ctx.path      = path_str;
         w->ctx.query     = query_str;
@@ -544,56 +745,38 @@ static void handle_conn_fiber(void* arg)
         w->ctx.body      = body_arr;
         w->ctx.user_data = NULL;
 
-        /* ---- Run middleware chain then the route handler (in this fiber) ---- */
         goc_http_ctx_t* ctx = &w->ctx;
         if (srv->middleware) {
             size_t n = goc_array_len(srv->middleware);
+            int middleware_ok = 1;
             for (size_t i = 0; i < n; i++) {
                 goc_http_middleware_t mw =
                     (goc_http_middleware_t)(uintptr_t)
                         goc_array_get(srv->middleware, i);
                 if (mw(ctx) != GOC_HTTP_OK) {
                     goc_take(goc_http_server_respond_error(ctx, 500,
-                                                       "Internal Server Error"));
-                    goc_io_handle_close((uv_handle_t*)conn, NULL);
-                    return;
+                                                           "Internal Server Error"));
+                    middleware_ok = 0;
+                    break;
                 }
             }
+            if (!middleware_ok) {
+                if (!w->keep_alive)
+                    break;
+                continue;
+            }
         }
-        GOC_DBG("handle_conn_fiber: calling handler\n");
+
         w->handler(ctx);
-        GOC_DBG("handle_conn_fiber: handler returned, closing conn=%p\n", (void*)conn);
-
-        /* ---- Close connection after handler returns ---- */
-        goc_io_handle_close((uv_handle_t*)conn, NULL);
-        return;
+        if (!w->keep_alive)
+            break;
     }
 
-stop_and_close:
-    /* Stop reading, drain the channel, close the connection. */
-    GOC_DBG("handle_conn_fiber: stop_and_close, calling read_stop on conn=%p\n", (void*)conn);
-    goc_io_read_stop((uv_stream_t*)conn);
-    for (;;) {
-        goc_val_t* v = goc_take(read_ch);
-        GOC_DBG("handle_conn_fiber: stop_and_close drain v=%p ok=%d\n", (void*)v, v ? (int)v->ok : -1);
-        if (!v || v->ok != GOC_OK) break;
-    }
     free(buf);
     goc_io_handle_close((uv_handle_t*)conn, NULL);
-    return;
-
-cleanup:
-    /* read_ch closed before we finished reading (client EOF/error). */
-    GOC_DBG("handle_conn_fiber: cleanup (early EOF/error), calling read_stop on conn=%p\n", (void*)conn);
-    goc_io_read_stop((uv_stream_t*)conn);
-    for (;;) {
-        goc_val_t* v = goc_take(read_ch);
-        GOC_DBG("handle_conn_fiber: cleanup drain v=%p ok=%d\n", (void*)v, v ? (int)v->ok : -1);
-        if (!v || v->ok != GOC_OK) break;
-    }
-    free(buf);
-    goc_io_handle_close((uv_handle_t*)conn, NULL);
-    GOC_DBG("handle_conn_fiber: cleanup complete\n");
+    GOC_DBG("handle_conn_fiber: connection closed conn=%p\n", (void*)conn);
+    if (atomic_fetch_sub_explicit(&srv->active_conns, 1, memory_order_release) == 1)
+        goc_close(srv->shutdown_ch);
 }
 
 /* =========================================================================
@@ -656,9 +839,10 @@ goc_chan* goc_http_server_respond_buf(goc_http_ctx_t* ctx, int status,
                         "HTTP/1.1 %d %s\r\n"
                         "Content-Type: %s\r\n"
                         "Content-Length: %zu\r\n"
-                        "Connection: close\r\n"
+                        "Connection: %s\r\n"
                         "\r\n",
-                        status, stat_str, content_type, len);
+                        status, stat_str, content_type, len,
+                        w->keep_alive ? "keep-alive" : "close");
     if (hlen < 0 || (size_t)hlen >= hdr_max) {
         memcpy(resp, "HTTP/1.1 500 Internal Server Error\r\n\r\n", 38);
         hlen = 38;
@@ -703,6 +887,7 @@ goc_http_request_opts_t* goc_http_request_opts(void)
     goc_http_request_opts_t* o =
         (goc_http_request_opts_t*)goc_malloc(sizeof(goc_http_request_opts_t));
     memset(o, 0, sizeof(*o));
+    o->pool = goc_current_or_default_pool();
     return o;
 }
 
@@ -752,6 +937,34 @@ static int parse_url(const char* url, char** out_host,
     }
 
     return 0;
+}
+
+static int http_client_parse_numeric_addr(const char* host,
+                                          uint16_t port,
+                                          struct sockaddr_storage* out_addr)
+{
+    if (!host || !out_addr)
+        return UV_EINVAL;
+
+    memset(out_addr, 0, sizeof(*out_addr));
+
+    int rc = uv_ip4_addr(host, port, (struct sockaddr_in*)out_addr);
+    if (rc == 0)
+        return 0;
+
+    if (host[0] == '[') {
+        size_t len = strlen(host);
+        if (len >= 2 && host[len - 1] == ']') {
+            char* bare = (char*)goc_malloc(len - 1);
+            memcpy(bare, host + 1, len - 2);
+            bare[len - 2] = '\0';
+            rc = uv_ip6_addr(bare, port, (struct sockaddr_in6*)out_addr);
+            if (rc == 0)
+                return 0;
+        }
+    }
+
+    return uv_ip6_addr(host, port, (struct sockaddr_in6*)out_addr);
 }
 
 /* Parse status line + headers from a raw response buffer.
@@ -825,11 +1038,28 @@ static int parse_response_head_buf(char* buf, size_t len,
     return 1;
 }
 
+static int response_has_connection_close(const goc_http_response_t* resp)
+{
+    if (!resp || !resp->headers)
+        return 0;
+    size_t n = goc_array_len(resp->headers);
+    for (size_t i = 0; i < n; i++) {
+        goc_http_header_t* h = (goc_http_header_t*)goc_array_get(resp->headers, i);
+        if (!h || !h->name || !h->value)
+            continue;
+        if (strcasecmp(h->name, "connection") == 0 &&
+            strcasecmp(h->value, "close") == 0)
+            return 1;
+    }
+    return 0;
+}
+
 /* Build raw HTTP/1.1 request (plain-malloc'd; caller must free). */
 static char* build_request(const char* method, const char* host,
                              const char* pq,   /* path[?query] */
                              const char* ct,   /* content-type, may be NULL */
                              const char* body, size_t body_len,
+                             int keep_alive,
                              goc_array*  extra_hdrs, /* may be NULL */
                              size_t* out_len)
 {
@@ -850,8 +1080,8 @@ static char* build_request(const char* method, const char* host,
 
 #define APPEND(...)  pos += (size_t)snprintf(buf + pos, cap - pos, __VA_ARGS__)
 
-    APPEND("%s %s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\n",
-           method, pq, host);
+        APPEND("%s %s HTTP/1.1\r\nHost: %s\r\nConnection: %s\r\n",
+            method, pq, host, keep_alive ? "keep-alive" : "close");
 
     if (ct && body_len > 0)
         APPEND("Content-Type: %s\r\nContent-Length: %zu\r\n", ct, body_len);
@@ -886,6 +1116,7 @@ static char* build_request(const char* method, const char* host,
  * ----------------------------------------------------------------------- */
 
 typedef struct {
+    uint64_t   req_id;
     char*      method;
     char*      host;
     uint16_t   port;
@@ -893,6 +1124,7 @@ typedef struct {
     char*      content_type;
     char*      body;       /* goc_malloc'd copy, may be NULL */
     size_t     body_len;
+    int        keep_alive;
     goc_array* extra_headers;
     goc_chan*  ch;         /* result channel — caller is waiting on this */
 } http_client_arg_t;
@@ -901,50 +1133,108 @@ static void http_client_fiber(void* arg)
 {
     http_client_arg_t* a = (http_client_arg_t*)arg;
     char* resp_buf = NULL;
-    GOC_DBG("http_client_fiber: started method=%s host=%s port=%u path=%s ch=%p\n",
-            a->method, a->host, (unsigned)a->port, a->path_and_query, (void*)a->ch);
+    uv_tcp_t* tcp = NULL;
+    int tcp_initialized = 0;
+    int using_keepalive_slot = 0;
+    int churn_slot_acquired = 0;
+    GOC_DBG("http_client_fiber[%llu]: started method=%s host=%s port=%u path=%s ch=%p keep_alive=%d slot={tcp=%p host=%s port=%u in_use=%d}\n",
+            (unsigned long long)a->req_id,
+            a->method, a->host, (unsigned)a->port, a->path_and_query, (void*)a->ch,
+            a->keep_alive,
+            (void*)g_http_ka_slot.tcp,
+            g_http_ka_slot.host ? g_http_ka_slot.host : "<null>",
+            (unsigned)g_http_ka_slot.port,
+            g_http_ka_slot.in_use);
 
-    /* --- DNS --- */
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family   = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    GOC_DBG("http_client_fiber: DNS lookup for host=%s\n", a->host);
-    goc_val_t* vdns = goc_take(goc_io_getaddrinfo(a->host, NULL, &hints));
-    GOC_DBG("http_client_fiber: DNS returned v=%p ok=%d\n", (void*)vdns, vdns ? (int)vdns->ok : -1);
-    if (!vdns || vdns->ok != GOC_OK) goto deliver_error;
-    goc_io_getaddrinfo_t* dns = (goc_io_getaddrinfo_t*)vdns->val;
-    if (!dns || dns->ok != GOC_IO_OK || !dns->res) { GOC_DBG("http_client_fiber: DNS error dns=%p\n", (void*)dns); goto deliver_error; }
+    if (!a->keep_alive) {
+        http_client_non_keepalive_acquire();
+        churn_slot_acquired = 1;
+    }
 
-    /* Pick first address and set port. */
-    struct sockaddr_storage addr;
-    memcpy(&addr, dns->res->ai_addr, dns->res->ai_addrlen);
-    if (addr.ss_family == AF_INET)
-        ((struct sockaddr_in*)&addr)->sin_port = htons(a->port);
-    else
-        ((struct sockaddr_in6*)&addr)->sin6_port = htons(a->port);
-    uv_freeaddrinfo(dns->res);
+    if (a->keep_alive &&
+        !g_http_ka_slot.in_use &&
+        keepalive_slot_matches(&g_http_ka_slot, a->host, a->port)) {
+        tcp = g_http_ka_slot.tcp;
+        tcp_initialized = 1;
+        g_http_ka_slot.in_use = 1;
+        using_keepalive_slot = 1;
+        GOC_DBG("http_client_fiber[%llu]: reusing keep-alive tcp=%p host=%s port=%u\n",
+            (unsigned long long)a->req_id, (void*)tcp, a->host, (unsigned)a->port);
+    }
 
-    /* --- TCP init + connect --- */
-    uv_tcp_t* tcp = (uv_tcp_t*)goc_malloc(sizeof(uv_tcp_t));
-    GOC_DBG("http_client_fiber: tcp_init tcp=%p\n", (void*)tcp);
-    int rc = goc_unbox_int(goc_take(goc_io_tcp_init(tcp))->val);
-    GOC_DBG("http_client_fiber: tcp_init rc=%d\n", rc);
-    if (rc < 0) { GOC_DBG("http_client_fiber: tcp_init failed\n"); goto deliver_error; }
+    if (!tcp) {
+        struct sockaddr_storage addr;
+        int have_addr = (http_client_parse_numeric_addr(a->host, a->port, &addr) == 0);
+        if (have_addr) {
+            GOC_DBG("http_client_fiber[%llu]: numeric host fast-path host=%s port=%u family=%d\n",
+                (unsigned long long)a->req_id, a->host, (unsigned)a->port, (int)addr.ss_family);
+        } else {
+            /* --- DNS --- */
+            struct addrinfo hints;
+            memset(&hints, 0, sizeof(hints));
+            hints.ai_family   = AF_UNSPEC;
+            hints.ai_socktype = SOCK_STREAM;
+            GOC_DBG("http_client_fiber[%llu]: DNS lookup for host=%s\n",
+                (unsigned long long)a->req_id, a->host);
+            goc_val_t* vdns = goc_take(goc_io_getaddrinfo(a->host, NULL, &hints));
+            GOC_DBG("http_client_fiber[%llu]: DNS returned v=%p ok=%d\n",
+                (unsigned long long)a->req_id, (void*)vdns, vdns ? (int)vdns->ok : -1);
+            if (!vdns || vdns->ok != GOC_OK) goto deliver_error;
+            goc_io_getaddrinfo_t* dns = (goc_io_getaddrinfo_t*)vdns->val;
+            if (!dns || dns->ok != GOC_IO_OK || !dns->res) {
+                GOC_DBG("http_client_fiber[%llu]: DNS error dns=%p\n",
+                    (unsigned long long)a->req_id, (void*)dns);
+                goto deliver_error;
+            }
 
-    rc = goc_unbox_int(
-        goc_take(goc_io_tcp_connect(tcp, (const struct sockaddr*)&addr))->val);
-    GOC_DBG("http_client_fiber: tcp_connect rc=%d\n", rc);
-    if (rc < 0) {
-        GOC_DBG("http_client_fiber: tcp_connect failed rc=%d\n", rc);
-        goc_io_handle_close((uv_handle_t*)tcp, NULL);
-        goto deliver_error;
+            /* Pick first address and set port. */
+            memcpy(&addr, dns->res->ai_addr, dns->res->ai_addrlen);
+            if (addr.ss_family == AF_INET)
+                ((struct sockaddr_in*)&addr)->sin_port = htons(a->port);
+            else
+                ((struct sockaddr_in6*)&addr)->sin6_port = htons(a->port);
+            uv_freeaddrinfo(dns->res);
+        }
+
+        /* --- TCP init + connect --- */
+        tcp = (uv_tcp_t*)goc_malloc(sizeof(uv_tcp_t));
+        GOC_DBG("http_client_fiber[%llu]: tcp_init tcp=%p\n",
+            (unsigned long long)a->req_id, (void*)tcp);
+        int rc = goc_unbox_int(goc_take(goc_io_tcp_init(tcp))->val);
+        GOC_DBG("http_client_fiber[%llu]: tcp_init rc=%d\n",
+            (unsigned long long)a->req_id, rc);
+        if (rc < 0) {
+            GOC_DBG("http_client_fiber[%llu]: tcp_init failed (tcp left uninitialized)\n",
+                    (unsigned long long)a->req_id);
+            tcp = NULL;
+            goto deliver_error;
+        }
+        tcp_initialized = 1;
+
+        rc = goc_unbox_int(
+            goc_take(goc_io_tcp_connect(tcp, (const struct sockaddr*)&addr))->val);
+        GOC_DBG("http_client_fiber[%llu]: tcp_connect rc=%d tcp=%p\n",
+            (unsigned long long)a->req_id, rc, (void*)tcp);
+        if (rc < 0) {
+            /* Includes ordinary connect failures and loop-teardown rejection
+             * when fire-and-forget requests outlive the runtime shutdown
+             * fence. Treat both as a normal error path and close the
+             * initialized handle. */
+            GOC_DBG("http_client_fiber[%llu]: tcp_connect failed rc=%d tcp=%p\n",
+                (unsigned long long)a->req_id, rc, (void*)tcp);
+            if (tcp_initialized)
+                goc_io_handle_close((uv_handle_t*)tcp, NULL);
+            tcp = NULL;
+            tcp_initialized = 0;
+            goto deliver_error;
+        }
     }
 
     /* --- Write request --- */
     size_t req_len;
     char* req_plain = build_request(a->method, a->host, a->path_and_query,
                                     a->content_type, a->body, a->body_len,
+                                    a->keep_alive,
                                     a->extra_headers, &req_len);
     /* Copy into goc_malloc so the GC keeps the buffer alive while
      * goc_io_write dispatches asynchronously to the event loop thread. */
@@ -953,13 +1243,19 @@ static void http_client_fiber(void* arg)
     free(req_plain);
 
     uv_buf_t wb = uv_buf_init(gc_req, (unsigned int)req_len);
-    GOC_DBG("http_client_fiber: writing request len=%zu\n", req_len);
-    rc = goc_unbox_int(
+    GOC_DBG("http_client_fiber[%llu]: writing request len=%zu tcp=%p\n",
+            (unsigned long long)a->req_id, req_len, (void*)tcp);
+    int rc = goc_unbox_int(
         goc_take(goc_io_write((uv_stream_t*)tcp, &wb, 1))->val);
-    GOC_DBG("http_client_fiber: write rc=%d\n", rc);
+    GOC_DBG("http_client_fiber[%llu]: write rc=%d tcp=%p\n",
+            (unsigned long long)a->req_id, rc, (void*)tcp);
     if (rc < 0) {
-        GOC_DBG("http_client_fiber: write failed\n");
-        goc_io_handle_close((uv_handle_t*)tcp, NULL);
+        GOC_DBG("http_client_fiber[%llu]: write failed tcp=%p\n",
+                (unsigned long long)a->req_id, (void*)tcp);
+        if (tcp_initialized)
+            goc_io_handle_close((uv_handle_t*)tcp, NULL);
+        tcp = NULL;
+        tcp_initialized = 0;
         goto deliver_error;
     }
 
@@ -971,16 +1267,21 @@ static void http_client_fiber(void* arg)
         ssize_t content_length = -1;
         size_t  body_start     = 0;
 
-        GOC_DBG("http_client_fiber: starting read on tcp=%p\n", (void*)tcp);
+        GOC_DBG("http_client_fiber[%llu]: starting read on tcp=%p\n",
+            (unsigned long long)a->req_id, (void*)tcp);
         goc_chan* rd = goc_io_read_start((uv_stream_t*)tcp);
-        GOC_DBG("http_client_fiber: read_ch=%p\n", (void*)rd);
+        GOC_DBG("http_client_fiber[%llu]: read_ch=%p\n",
+            (unsigned long long)a->req_id, (void*)rd);
         for (;;) {
-            GOC_DBG("http_client_fiber: waiting for response chunk resp_len=%zu\n", resp_len);
+            GOC_DBG("http_client_fiber[%llu]: waiting for response chunk resp_len=%zu\n",
+                (unsigned long long)a->req_id, resp_len);
             goc_val_t* v = goc_take(rd);
-            GOC_DBG("http_client_fiber: response goc_take v=%p ok=%d\n", (void*)v, v ? (int)v->ok : -1);
+            GOC_DBG("http_client_fiber[%llu]: response goc_take v=%p ok=%d\n",
+                (unsigned long long)a->req_id, (void*)v, v ? (int)v->ok : -1);
             if (!v || v->ok != GOC_OK) break;
             goc_io_read_t* r = (goc_io_read_t*)v->val;
-            GOC_DBG("http_client_fiber: response chunk nread=%zd\n", r->nread);
+            GOC_DBG("http_client_fiber[%llu]: response chunk nread=%zd\n",
+                (unsigned long long)a->req_id, r->nread);
             if (r->nread < 0) break;
 
             /* Grow plain-malloc buffer. */
@@ -1008,19 +1309,31 @@ static void http_client_fiber(void* arg)
                 if (got >= (size_t)content_length) break;
             }
         }
-        GOC_DBG("http_client_fiber: read loop done, stopping read rd=%p tcp=%p\n", (void*)rd, (void*)tcp);
+        GOC_DBG("http_client_fiber[%llu]: read loop done, stopping read rd=%p tcp=%p\n",
+            (unsigned long long)a->req_id, (void*)rd, (void*)tcp);
         goc_io_read_stop((uv_stream_t*)tcp);
         for (;;) {
             goc_val_t* dv = goc_take(rd);
-            GOC_DBG("http_client_fiber: read drain dv=%p ok=%d\n", (void*)dv, dv ? (int)dv->ok : -1);
+            GOC_DBG("http_client_fiber[%llu]: read drain dv=%p ok=%d\n",
+                (unsigned long long)a->req_id, (void*)dv, dv ? (int)dv->ok : -1);
             if (!dv || dv->ok != GOC_OK)
                 break;
         }
-        GOC_DBG("http_client_fiber: read drain complete, closing tcp=%p\n", (void*)tcp);
-        goc_io_handle_close((uv_handle_t*)tcp, NULL);
+        GOC_DBG("http_client_fiber[%llu]: read drain complete tcp=%p\n",
+            (unsigned long long)a->req_id, (void*)tcp);
 
         /* --- Attach body and deliver --- */
         if (!response) {
+            if (using_keepalive_slot)
+                keepalive_slot_drop(&g_http_ka_slot);
+            else if (tcp) {
+                GOC_DBG("http_client_fiber[%llu]: closing tcp=%p after missing response\n",
+                        (unsigned long long)a->req_id, (void*)tcp);
+                if (tcp_initialized)
+                    goc_io_handle_close((uv_handle_t*)tcp, NULL);
+                tcp = NULL;
+                tcp_initialized = 0;
+            }
             if (resp_buf) free(resp_buf);
             goto deliver_error;
         }
@@ -1033,21 +1346,76 @@ static void http_client_fiber(void* arg)
         if (resp_buf) free(resp_buf);
         response->body     = body;
         response->body_len = blen;
-        GOC_DBG("http_client_fiber: delivering response status=%d blen=%zu on ch=%p\n",
-                response->status, blen, (void*)a->ch);
-        goc_put_cb(a->ch, response, close_on_put, a->ch);
+
+        int can_keep = a->keep_alive &&
+                       content_length >= 0 &&
+                       !response_has_connection_close(response);
+        if (can_keep) {
+            if (using_keepalive_slot) {
+                g_http_ka_slot.in_use = 0;
+                GOC_DBG("http_client_fiber[%llu]: returned keep-alive tcp=%p to slot\n",
+                        (unsigned long long)a->req_id, (void*)tcp);
+            } else if (!g_http_ka_slot.in_use) {
+                keepalive_slot_drop(&g_http_ka_slot);
+                g_http_ka_slot.tcp    = tcp;
+                g_http_ka_slot.host   = a->host;
+                g_http_ka_slot.port   = a->port;
+                g_http_ka_slot.in_use = 0;
+                GOC_DBG("http_client_fiber[%llu]: stored tcp=%p in keep-alive slot host=%s port=%u\n",
+                        (unsigned long long)a->req_id, (void*)tcp, a->host, (unsigned)a->port);
+                tcp = NULL;
+                tcp_initialized = 0;
+            } else {
+                GOC_DBG("http_client_fiber[%llu]: keep-alive slot busy, closing tcp=%p\n",
+                        (unsigned long long)a->req_id, (void*)tcp);
+                if (tcp_initialized)
+                    goc_io_handle_close((uv_handle_t*)tcp, NULL);
+                tcp_initialized = 0;
+            }
+        } else {
+            if (using_keepalive_slot)
+                keepalive_slot_drop(&g_http_ka_slot);
+            else if (tcp) {
+                GOC_DBG("http_client_fiber[%llu]: closing non-keepalive tcp=%p can_keep=%d\n",
+                        (unsigned long long)a->req_id, (void*)tcp, can_keep);
+                if (tcp_initialized)
+                    goc_io_handle_close((uv_handle_t*)tcp, NULL);
+                tcp_initialized = 0;
+            }
+        }
+
+        GOC_DBG("http_client_fiber[%llu]: delivering response status=%d blen=%zu on ch=%p\n",
+                (unsigned long long)a->req_id, response->status, blen, (void*)a->ch);
+        goc_put(a->ch, response);
+        goc_close(a->ch);
+        if (churn_slot_acquired)
+            http_client_non_keepalive_release();
         return;
     }
 
 deliver_error: {
-    GOC_DBG("http_client_fiber: deliver_error, delivering status=0 on ch=%p\n", (void*)a->ch);
+    GOC_DBG("http_client_fiber[%llu]: deliver_error, delivering status=0 on ch=%p tcp=%p using_slot=%d\n",
+            (unsigned long long)a->req_id, (void*)a->ch, (void*)tcp, using_keepalive_slot);
+    if (using_keepalive_slot)
+        keepalive_slot_drop(&g_http_ka_slot);
+    else if (tcp) {
+        GOC_DBG("http_client_fiber[%llu]: closing tcp=%p on error path (initialized=%d)\n",
+                (unsigned long long)a->req_id, (void*)tcp, tcp_initialized);
+        if (tcp_initialized)
+            goc_io_handle_close((uv_handle_t*)tcp, NULL);
+        tcp = NULL;
+        tcp_initialized = 0;
+    }
     if (resp_buf) free(resp_buf);
     goc_http_response_t* r =
         (goc_http_response_t*)goc_malloc(sizeof(goc_http_response_t));
     memset(r, 0, sizeof(*r));
     r->headers = goc_array_make(0);
     r->body    = "";
-    goc_put_cb(a->ch, r, close_on_put, a->ch);
+    goc_put(a->ch, r);
+    goc_close(a->ch);
+    if (churn_slot_acquired)
+        http_client_non_keepalive_release();
     }
 }
 
@@ -1068,7 +1436,8 @@ goc_chan* goc_http_request(const char* method, const char* url,
         memset(r, 0, sizeof(*r));
         r->headers = goc_array_make(0);
         r->body    = "";
-        goc_put_cb(ch, r, close_on_put, ch);
+        goc_put(ch, r);
+        goc_close(ch);
         return ch;
     }
 
@@ -1081,6 +1450,7 @@ goc_chan* goc_http_request(const char* method, const char* url,
 
     http_client_arg_t* a =
         (http_client_arg_t*)goc_malloc(sizeof(http_client_arg_t));
+    a->req_id         = atomic_fetch_add_explicit(&g_http_client_req_seq, 1, memory_order_relaxed) + 1;
     a->method         = (char*)method;  /* caller's lifetime >= fiber */
     a->host           = host;
     a->port           = port;
@@ -1088,10 +1458,18 @@ goc_chan* goc_http_request(const char* method, const char* url,
     a->content_type   = content_type ? (char*)content_type : NULL;
     a->body           = body_copy;
     a->body_len       = body_len;
+    a->keep_alive     = opts ? opts->keep_alive : 0;
     a->extra_headers  = opts ? opts->headers : NULL;
     a->ch             = ch;
 
-    goc_go_on(goc_default_pool(), http_client_fiber, a);
+            GOC_DBG("goc_http_request[%llu]: method=%s url=%s host=%s port=%u path=%s keep_alive=%d timeout_ms=%llu ch=%p\n",
+            (unsigned long long)a->req_id, method, url, host, (unsigned)port, pq,
+            opts ? opts->keep_alive : 0,
+                (unsigned long long)(opts ? opts->timeout_ms : 0),
+            (void*)ch);
+
+    goc_pool* req_pool = (opts && opts->pool) ? opts->pool : goc_current_or_default_pool();
+    goc_go_on(req_pool, http_client_fiber, a);
 
     /* Honour optional timeout (fiber context only). */
     if (opts && opts->timeout_ms > 0 && goc_in_fiber()) {
@@ -1112,12 +1490,14 @@ goc_chan* goc_http_request(const char* method, const char* url,
             memset(r, 0, sizeof(*r));
             r->headers = goc_array_make(0);
             r->body    = "";
-            goc_put_cb(toch, r, close_on_put, toch);
+            goc_put(toch, r);
+            goc_close(toch);
             return toch;
         }
         /* Response arrived before timeout — re-wrap on a fresh channel. */
         goc_chan* ch2 = goc_chan_make(1);
-        goc_put_cb(ch2, res->value.val, close_on_put, ch2);
+        goc_put(ch2, res->value.val);
+        goc_close(ch2);
         return ch2;
     }
 

--- a/src/goc_io.c
+++ b/src/goc_io.c
@@ -55,6 +55,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <stdatomic.h>
 #include <uv.h>
 #include <gc.h>
 #include "../include/goc_io.h"
@@ -385,30 +386,104 @@ goc_chan* goc_io_fs_sendfile(uv_file out_fd, uv_file in_fd,
 typedef struct {
     uv_getaddrinfo_t req;   /* MUST be first member */
     goc_chan*        ch;
+    long             submit_seq;
 } goc_getaddrinfo_ctx_t;
+
+/* Bounded DNS trace for root-cause diagnostics (enabled unconditionally).
+ * Keeps output finite while still exposing submit/callback imbalance. */
+static _Atomic long g_dns_submit_count = 0;
+static _Atomic long g_dns_cb_count = 0;
+static _Atomic long g_dns_inflight = 0;
+
+#define GOC_DNS_TRACE_LIMIT 512L
+#define GOC_DNS_TRACE_SPARSE_INTERVAL 64L
+
+static int dns_trace_should_log(long seq, long inflight)
+{
+    return (seq <= GOC_DNS_TRACE_LIMIT) ||
+           (inflight >= 32 && ((seq % GOC_DNS_TRACE_SPARSE_INTERVAL) == 0));
+}
+
+static void dns_trace_submit(goc_getaddrinfo_ctx_t* ctx,
+                             const char* node,
+                             const char* service)
+{
+    long s = atomic_fetch_add_explicit(&g_dns_submit_count, 1, memory_order_relaxed) + 1;
+    long in = atomic_fetch_add_explicit(&g_dns_inflight, 1, memory_order_relaxed) + 1;
+    ctx->submit_seq = s;
+    if (dns_trace_should_log(s, in)) {
+        fprintf(stderr,
+                "[DNS_TRACE] submit#%ld req=%p ctx=%p ch=%p node=%s service=%s loop=%p shutdown=%d inflight=%ld\n",
+                s,
+                (void*)&ctx->req,
+                (void*)ctx,
+                (void*)ctx->ch,
+                node ? node : "<null>",
+                service ? service : "<null>",
+                (void*)g_loop,
+                goc_loop_is_shutting_down(),
+                in);
+        fflush(stderr);
+    }
+}
+
+static void dns_trace_submit_fail(goc_getaddrinfo_ctx_t* ctx, int rc)
+{
+    /* Submit was already counted; back out inflight to avoid negative drift. */
+    long in = atomic_fetch_sub_explicit(&g_dns_inflight, 1, memory_order_relaxed) - 1;
+    if (dns_trace_should_log(ctx->submit_seq, in)) {
+        fprintf(stderr,
+                "[DNS_TRACE] submit-fail#%ld req=%p ctx=%p ch=%p rc=%d loop=%p shutdown=%d inflight=%ld\n",
+                ctx->submit_seq,
+                (void*)&ctx->req,
+                (void*)ctx,
+                (void*)ctx->ch,
+                rc,
+                (void*)g_loop,
+                goc_loop_is_shutting_down(),
+                in);
+        fflush(stderr);
+    }
+}
+
+static void dns_trace_callback(goc_getaddrinfo_ctx_t* ctx, int status)
+{
+    long c = atomic_fetch_add_explicit(&g_dns_cb_count, 1, memory_order_relaxed) + 1;
+    long in = atomic_fetch_sub_explicit(&g_dns_inflight, 1, memory_order_relaxed) - 1;
+    if (dns_trace_should_log(ctx->submit_seq ? ctx->submit_seq : c, in)) {
+        fprintf(stderr,
+                "[DNS_TRACE] cb#%ld submit#=%ld req=%p ctx=%p ch=%p status=%d loop=%p shutdown=%d inflight=%ld\n",
+                c,
+                ctx->submit_seq,
+                (void*)&ctx->req,
+                (void*)ctx,
+                (void*)ctx->ch,
+                status,
+                ctx->req.loop ? (void*)ctx->req.loop : (void*)g_loop,
+                goc_loop_is_shutting_down(),
+                in);
+        fflush(stderr);
+    }
+}
 
 static void on_getaddrinfo(uv_getaddrinfo_t* req, int status,
                            struct addrinfo* res)
 {
     goc_getaddrinfo_ctx_t* ctx = (goc_getaddrinfo_ctx_t*)req;
+    dns_trace_callback(ctx, status);
     goc_io_getaddrinfo_t*  r   = (goc_io_getaddrinfo_t*)goc_malloc(
                                      sizeof(goc_io_getaddrinfo_t));
     r->ok  = (status == 0) ? GOC_IO_OK : GOC_IO_ERR;
     r->res = res;
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, r, close_on_put, ctx->ch);
+    free(ctx);
 }
 
 goc_chan* goc_io_getaddrinfo(const char* node, const char* service,
                                 const struct addrinfo* hints)
 {
     goc_chan*              ch  = goc_chan_make(1);
-    goc_getaddrinfo_ctx_t* ctx = (goc_getaddrinfo_ctx_t*)goc_malloc(
-                                     sizeof(goc_getaddrinfo_ctx_t));
-    ctx->ch = ch;
-    int rc = uv_getaddrinfo(g_loop, &ctx->req, on_getaddrinfo,
-                            node, service, hints);
-    if (rc < 0) {
+    if (goc_loop_is_shutting_down()) {
         goc_io_getaddrinfo_t* r = (goc_io_getaddrinfo_t*)goc_malloc(
                                    sizeof(goc_io_getaddrinfo_t));
         r->ok  = GOC_IO_ERR;
@@ -416,7 +491,33 @@ goc_chan* goc_io_getaddrinfo(const char* node, const char* service,
         goc_put_cb(ch, r, close_on_put, ch);
         return ch;
     }
-    gc_handle_register(ctx);
+    goc_getaddrinfo_ctx_t* ctx = (goc_getaddrinfo_ctx_t*)malloc(
+                                     sizeof(goc_getaddrinfo_ctx_t));
+    if (!ctx) {
+        goc_io_getaddrinfo_t* r = (goc_io_getaddrinfo_t*)goc_malloc(
+                                   sizeof(goc_io_getaddrinfo_t));
+        r->ok  = GOC_IO_ERR;
+        r->res = NULL;
+        goc_put_cb(ch, r, close_on_put, ch);
+        return ch;
+    }
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->ch = ch;
+    /* Trace submit before calling into libuv to avoid a race where callback
+     * runs and frees ctx before post-call tracing executes on another thread. */
+    dns_trace_submit(ctx, node, service);
+    int rc = uv_getaddrinfo(g_loop, &ctx->req, on_getaddrinfo,
+                            node, service, hints);
+    if (rc < 0) {
+        dns_trace_submit_fail(ctx, rc);
+        free(ctx);
+        goc_io_getaddrinfo_t* r = (goc_io_getaddrinfo_t*)goc_malloc(
+                                   sizeof(goc_io_getaddrinfo_t));
+        r->ok  = GOC_IO_ERR;
+        r->res = NULL;
+        goc_put_cb(ch, r, close_on_put, ch);
+        return ch;
+    }
     return ch;
 }
 
@@ -447,18 +548,16 @@ static void on_getnameinfo(uv_getnameinfo_t* req, int status,
         r->service[0] = '\0';
     r->hostname[sizeof(r->hostname) - 1] = '\0';
     r->service[sizeof(r->service)  - 1] = '\0';
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, r, close_on_put, ctx->ch);
+    free(ctx);
 }
 
 goc_chan* goc_io_getnameinfo(const struct sockaddr* addr, int flags)
 {
     goc_chan*              ch  = goc_chan_make(1);
-    goc_getnameinfo_ctx_t* ctx = (goc_getnameinfo_ctx_t*)goc_malloc(
+    goc_getnameinfo_ctx_t* ctx = (goc_getnameinfo_ctx_t*)malloc(
                                      sizeof(goc_getnameinfo_ctx_t));
-    ctx->ch = ch;
-    int rc = uv_getnameinfo(g_loop, &ctx->req, on_getnameinfo, addr, flags);
-    if (rc < 0) {
+    if (!ctx) {
         goc_io_getnameinfo_t* r = (goc_io_getnameinfo_t*)goc_malloc(
                                    sizeof(goc_io_getnameinfo_t));
         r->ok         = GOC_IO_ERR;
@@ -467,7 +566,18 @@ goc_chan* goc_io_getnameinfo(const struct sockaddr* addr, int flags)
         goc_put_cb(ch, r, close_on_put, ch);
         return ch;
     }
-    gc_handle_register(ctx);
+    ctx->ch = ch;
+    int rc = uv_getnameinfo(g_loop, &ctx->req, on_getnameinfo, addr, flags);
+    if (rc < 0) {
+        free(ctx);
+        goc_io_getnameinfo_t* r = (goc_io_getnameinfo_t*)goc_malloc(
+                                   sizeof(goc_io_getnameinfo_t));
+        r->ok         = GOC_IO_ERR;
+        r->hostname[0] = '\0';
+        r->service[0]  = '\0';
+        goc_put_cb(ch, r, close_on_put, ch);
+        return ch;
+    }
     return ch;
 }
 
@@ -646,14 +756,26 @@ int goc_io_read_stop(uv_stream_t* stream)
 typedef struct {
     uv_write_t  req;    /* MUST be first member */
     goc_chan*   ch;
+    uv_buf_t*   bufs_copy;
+    unsigned    nbufs;
 } goc_write_ctx_t;
+
+static void free_owned_bufs(uv_buf_t* bufs, unsigned nbufs)
+{
+    if (!bufs)
+        return;
+    for (unsigned i = 0; i < nbufs; i++)
+        free(bufs[i].base);
+    free(bufs);
+}
 
 static void on_write_cb(uv_write_t* req, int status)
 {
     goc_write_ctx_t* ctx = (goc_write_ctx_t*)req;
     GOC_DBG("on_write_cb: status=%d ch=%p\n", status, (void*)ctx->ch);
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, SCALAR(status), close_on_put, ctx->ch);
+    free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+    free(ctx);
 }
 
 typedef struct {
@@ -667,14 +789,57 @@ static void on_write_dispatch(void* arg)
 {
     goc_write_dispatch_t* d   = (goc_write_dispatch_t*)arg;
     GOC_DBG("on_write_dispatch: handle=%p nbufs=%u ch=%p\n", (void*)d->handle, d->nbufs, (void*)d->ch);
-    goc_write_ctx_t*      ctx = (goc_write_ctx_t*)goc_malloc(sizeof(goc_write_ctx_t));
+    /* Preflight: if the handle is NULL/closing or the loop is shutting down,
+     * reject the write immediately.  A write submitted to a dying stream can
+     * become the sole active libuv request on the loop, which trips libuv's
+     * internal assertion uv__has_active_reqs(stream->loop) in
+     * uv__write_callbacks after the req is unregistered. */
+    if (!d->handle ||
+        uv_is_closing((uv_handle_t*)d->handle) ||
+        goc_loop_is_shutting_down()) {
+        GOC_DBG("on_write_dispatch: preflight-reject handle=%p closing=%d shutdown=%d\n",
+                (void*)d->handle,
+                d->handle ? uv_is_closing((uv_handle_t*)d->handle) : -1,
+                goc_loop_is_shutting_down());
+        goc_put_cb(d->ch, SCALAR(UV_ECANCELED), close_on_put, d->ch);
+        return;
+    }
+    goc_write_ctx_t*      ctx = (goc_write_ctx_t*)malloc(sizeof(goc_write_ctx_t));
+    if (!ctx) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        return;
+    }
     ctx->ch = d->ch;
-    int rc = uv_write(&ctx->req, d->handle, d->bufs, d->nbufs, on_write_cb);
+    ctx->nbufs = d->nbufs;
+    ctx->bufs_copy = (uv_buf_t*)calloc(d->nbufs, sizeof(uv_buf_t));
+    if (!ctx->bufs_copy) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        free(ctx);
+        return;
+    }
+
+    for (unsigned i = 0; i < d->nbufs; i++) {
+        size_t len = d->bufs[i].len;
+        char* mem = NULL;
+        if (len > 0) {
+            mem = (char*)malloc(len);
+            if (!mem) {
+                goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+                free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+                free(ctx);
+                return;
+            }
+            memcpy(mem, d->bufs[i].base, len);
+        }
+        ctx->bufs_copy[i] = uv_buf_init(mem, (unsigned int)len);
+    }
+
+    int rc = uv_write(&ctx->req, d->handle, ctx->bufs_copy, d->nbufs, on_write_cb);
     GOC_DBG("on_write_dispatch: uv_write rc=%d\n", rc);
     if (rc < 0) {
         goc_put_cb(ctx->ch, SCALAR(rc), close_on_put, ctx->ch);
-    } else {
-        gc_handle_register(ctx);
+        free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+        free(ctx);
     }
 }
 
@@ -707,14 +872,17 @@ goc_chan* goc_io_write(uv_stream_t* handle,
 typedef struct {
     uv_write_t   req;         /* MUST be first member */
     goc_chan*    ch;
+    uv_buf_t*    bufs_copy;
+    unsigned     nbufs;
 } goc_write2_ctx_t;
 
 /* Reuse on_write_cb for write2 (same signature, same semantics). */
 static void on_write2_cb(uv_write_t* req, int status)
 {
     goc_write2_ctx_t* ctx = (goc_write2_ctx_t*)req;
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, SCALAR(status), close_on_put, ctx->ch);
+    free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+    free(ctx);
 }
 
 typedef struct {
@@ -728,15 +896,49 @@ typedef struct {
 static void on_write2_dispatch(void* arg)
 {
     goc_write2_dispatch_t* d   = (goc_write2_dispatch_t*)arg;
-    goc_write2_ctx_t*      ctx = (goc_write2_ctx_t*)goc_malloc(
+    if (!d->handle ||
+        uv_is_closing((uv_handle_t*)d->handle) ||
+        goc_loop_is_shutting_down()) {
+        goc_put_cb(d->ch, SCALAR(UV_ECANCELED), close_on_put, d->ch);
+        return;
+    }
+    goc_write2_ctx_t*      ctx = (goc_write2_ctx_t*)malloc(
                                      sizeof(goc_write2_ctx_t));
+    if (!ctx) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        return;
+    }
     ctx->ch = d->ch;
-    int rc = uv_write2(&ctx->req, d->handle, d->bufs, d->nbufs,
+    ctx->nbufs = d->nbufs;
+    ctx->bufs_copy = (uv_buf_t*)calloc(d->nbufs, sizeof(uv_buf_t));
+    if (!ctx->bufs_copy) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        free(ctx);
+        return;
+    }
+
+    for (unsigned i = 0; i < d->nbufs; i++) {
+        size_t len = d->bufs[i].len;
+        char* mem = NULL;
+        if (len > 0) {
+            mem = (char*)malloc(len);
+            if (!mem) {
+                goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+                free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+                free(ctx);
+                return;
+            }
+            memcpy(mem, d->bufs[i].base, len);
+        }
+        ctx->bufs_copy[i] = uv_buf_init(mem, (unsigned int)len);
+    }
+
+    int rc = uv_write2(&ctx->req, d->handle, ctx->bufs_copy, d->nbufs,
                        d->send_handle, on_write2_cb);
     if (rc < 0) {
         goc_put_cb(ctx->ch, SCALAR(rc), close_on_put, ctx->ch);
-    } else {
-        gc_handle_register(ctx);
+        free_owned_bufs(ctx->bufs_copy, ctx->nbufs);
+        free(ctx);
     }
 }
 
@@ -772,8 +974,8 @@ typedef struct {
 static void on_shutdown_cb(uv_shutdown_t* req, int status)
 {
     goc_shutdown_ctx_t* ctx = (goc_shutdown_ctx_t*)req;
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, SCALAR(status), close_on_put, ctx->ch);
+    free(ctx);
 }
 
 typedef struct {
@@ -784,14 +986,17 @@ typedef struct {
 static void on_shutdown_dispatch(void* arg)
 {
     goc_shutdown_dispatch_t* d   = (goc_shutdown_dispatch_t*)arg;
-    goc_shutdown_ctx_t*      ctx = (goc_shutdown_ctx_t*)goc_malloc(
+    goc_shutdown_ctx_t*      ctx = (goc_shutdown_ctx_t*)malloc(
                                        sizeof(goc_shutdown_ctx_t));
+    if (!ctx) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        return;
+    }
     ctx->ch = d->ch;
     int rc = uv_shutdown(&ctx->req, d->handle, on_shutdown_cb);
     if (rc < 0) {
         goc_put_cb(ctx->ch, SCALAR(rc), close_on_put, ctx->ch);
-    } else {
-        gc_handle_register(ctx);
+        free(ctx);
     }
 }
 
@@ -814,14 +1019,32 @@ goc_chan* goc_io_shutdown_stream(uv_stream_t* handle)
 typedef struct {
     uv_connect_t req;   /* MUST be first member */
     goc_chan*    ch;
+    int          inflight_tracked;
 } goc_connect_ctx_t;
+
+/* Soft guardrail: avoid feeding unbounded connect bursts into libuv under
+ * teardown/churn stress. Above this threshold, new connect submits fail-fast
+ * with UV_EBUSY so callers receive a normal error instead of destabilizing
+ * the loop's internal request accounting. */
+#define GOC_CONN_INFLIGHT_SOFT_MAX 128L
+
+static _Atomic long g_tcp_connect_inflight = 0;
 
 static void on_connect_cb(uv_connect_t* req, int status)
 {
     goc_connect_ctx_t* ctx = (goc_connect_ctx_t*)req;
+    if (ctx->inflight_tracked) {
+        long prev = atomic_fetch_sub_explicit(&g_tcp_connect_inflight,
+                                              1,
+                                              memory_order_acq_rel);
+        if (prev <= 0)
+            atomic_store_explicit(&g_tcp_connect_inflight,
+                                  0,
+                                  memory_order_release);
+    }
     GOC_DBG("on_connect_cb: status=%d ch=%p\n", status, (void*)ctx->ch);
-    gc_handle_unregister(ctx);
     goc_put_cb(ctx->ch, SCALAR(status), close_on_put, ctx->ch);
+    free(ctx);
 }
 
 typedef struct {
@@ -830,21 +1053,76 @@ typedef struct {
     goc_chan*           ch;
 } goc_tcp_connect_dispatch_t;
 
+static int connect_dispatch_preflight(uv_handle_t* handle)
+{
+    if (!handle)
+        return UV_EINVAL;
+    if (handle->type != UV_TCP)
+        return UV_EINVAL;
+    if (handle->loop == NULL)
+        return UV_EINVAL;
+    if (handle->loop != g_loop)
+        return UV_EINVAL;
+    if (goc_loop_is_shutting_down())
+        return UV_ECANCELED;
+    if (uv_is_closing(handle))
+        return UV_ECANCELED;
+    return 0;
+}
+
+static int connect_dispatch_overloaded(void)
+{
+    long in = atomic_load_explicit(&g_tcp_connect_inflight, memory_order_relaxed);
+    return (in >= GOC_CONN_INFLIGHT_SOFT_MAX);
+}
+
 static void on_tcp_connect_dispatch(void* arg)
 {
     goc_tcp_connect_dispatch_t* d   = (goc_tcp_connect_dispatch_t*)arg;
-    GOC_DBG("on_tcp_connect_dispatch: handle=%p ch=%p\n", (void*)d->handle, (void*)d->ch);
-    goc_connect_ctx_t*          ctx = (goc_connect_ctx_t*)goc_malloc(
+    GOC_DBG("on_tcp_connect_dispatch: handle=%p ch=%p loop=%p closing=%d active=%d\n",
+            (void*)d->handle, (void*)d->ch,
+            d->handle ? (void*)d->handle->loop : NULL,
+            d->handle ? uv_is_closing((uv_handle_t*)d->handle) : -1,
+            d->handle ? uv_is_active((uv_handle_t*)d->handle) : -1);
+    int preflight_rc = connect_dispatch_preflight((uv_handle_t*)d->handle);
+    if (preflight_rc < 0) {
+        GOC_DBG("on_tcp_connect_dispatch: rejecting connect handle=%p rc=%d shutdown=%d\n",
+                (void*)d->handle, preflight_rc, goc_loop_is_shutting_down());
+        goc_put_cb(d->ch, SCALAR(preflight_rc), close_on_put, d->ch);
+        return;
+    }
+    if (connect_dispatch_overloaded()) {
+        GOC_DBG("on_tcp_connect_dispatch: rejecting connect handle=%p rc=%d inflight=%ld max=%ld\n",
+                (void*)d->handle,
+                UV_EBUSY,
+                atomic_load_explicit(&g_tcp_connect_inflight, memory_order_relaxed),
+                GOC_CONN_INFLIGHT_SOFT_MAX);
+        goc_put_cb(d->ch, SCALAR(UV_EBUSY), close_on_put, d->ch);
+        return;
+    }
+    goc_connect_ctx_t*          ctx = (goc_connect_ctx_t*)malloc(
                                           sizeof(goc_connect_ctx_t));
+    if (!ctx) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        return;
+    }
+    memset(ctx, 0, sizeof(*ctx));
     ctx->ch = d->ch;
+    ctx->inflight_tracked = 0;
     int rc = uv_tcp_connect(&ctx->req, d->handle,
                             (const struct sockaddr*)&d->addr,
                             on_connect_cb);
+    if (rc == 0) {
+        ctx->inflight_tracked = 1;
+        atomic_fetch_add_explicit(&g_tcp_connect_inflight,
+                                  1,
+                                  memory_order_acq_rel);
+    }
     GOC_DBG("on_tcp_connect_dispatch: uv_tcp_connect rc=%d\n", rc);
     if (rc < 0) {
+        ctx->inflight_tracked = 0;
         goc_put_cb(ctx->ch, SCALAR(rc), close_on_put, ctx->ch);
-    } else {
-        gc_handle_register(ctx);
+        free(ctx);
     }
 }
 
@@ -862,7 +1140,9 @@ goc_chan* goc_io_tcp_connect(uv_tcp_t* handle, const struct sockaddr* addr)
                ? sizeof(struct sockaddr_in6)
                : sizeof(struct sockaddr_in));
     d->ch = ch;
-    post_on_loop(on_tcp_connect_dispatch, d);
+    int rc = post_on_loop_checked(on_tcp_connect_dispatch, d);
+    if (rc < 0)
+        goc_put_cb(ch, SCALAR(rc), close_on_put, ch);
     return ch;
 }
 
@@ -882,11 +1162,22 @@ typedef struct {
 static void on_pipe_connect_dispatch(void* arg)
 {
     goc_pipe_connect_dispatch_t* d   = (goc_pipe_connect_dispatch_t*)arg;
-    goc_connect_ctx_t*           ctx = (goc_connect_ctx_t*)goc_malloc(
+    int preflight_rc = connect_dispatch_preflight((uv_handle_t*)d->handle);
+    if (preflight_rc < 0) {
+        GOC_DBG("on_pipe_connect_dispatch: rejecting connect handle=%p rc=%d shutdown=%d\n",
+                (void*)d->handle, preflight_rc, goc_loop_is_shutting_down());
+        goc_put_cb(d->ch, SCALAR(preflight_rc), close_on_put, d->ch);
+        return;
+    }
+    goc_connect_ctx_t*           ctx = (goc_connect_ctx_t*)malloc(
                                            sizeof(goc_connect_ctx_t));
+    if (!ctx) {
+        goc_put_cb(d->ch, SCALAR(UV_ENOMEM), close_on_put, d->ch);
+        return;
+    }
+    memset(ctx, 0, sizeof(*ctx));
     ctx->ch = d->ch;
     uv_pipe_connect(&ctx->req, d->handle, d->name, on_connect_cb);
-    gc_handle_register(ctx);
 }
 
 goc_chan* goc_io_pipe_connect(uv_pipe_t* handle, const char* name)
@@ -899,7 +1190,9 @@ goc_chan* goc_io_pipe_connect(uv_pipe_t* handle, const char* name)
     d->name   = (char*)goc_malloc(name_len + 1);   /* copied so the caller's string can be freed */
     strcpy(d->name, name);
     d->ch = ch;
-    post_on_loop(on_pipe_connect_dispatch, d);
+    int rc = post_on_loop_checked(on_pipe_connect_dispatch, d);
+    if (rc < 0)
+        goc_put_cb(ch, SCALAR(rc), close_on_put, ch);
     return ch;
 }
 
@@ -1257,17 +1550,49 @@ void goc_io_handle_unregister(uv_handle_t* handle)
     gc_handle_unregister(handle);
 }
 
-typedef struct {
-    uv_close_cb user_cb;
-} goc_handle_close_ctx_t;
+typedef struct goc_handle_close_reg {
+    uv_handle_t* handle;
+    uv_close_cb  user_cb;
+    struct goc_handle_close_reg* next;
+} goc_handle_close_reg_t;
+
+/* Accessed only on the libuv loop thread (on_handle_close_dispatch and
+ * on_goc_handle_close both run there), so no extra synchronization needed. */
+static goc_handle_close_reg_t* g_handle_close_regs = NULL;
+
+static void register_handle_close_cb(uv_handle_t* handle, uv_close_cb user_cb)
+{
+    goc_handle_close_reg_t* n =
+        (goc_handle_close_reg_t*)goc_malloc(sizeof(goc_handle_close_reg_t));
+    n->handle  = handle;
+    n->user_cb = user_cb;
+    n->next    = g_handle_close_regs;
+    g_handle_close_regs = n;
+}
+
+static uv_close_cb take_handle_close_cb(uv_handle_t* handle)
+{
+    goc_handle_close_reg_t* prev = NULL;
+    goc_handle_close_reg_t* cur  = g_handle_close_regs;
+    while (cur) {
+        if (cur->handle == handle) {
+            uv_close_cb cb = cur->user_cb;
+            if (prev)
+                prev->next = cur->next;
+            else
+                g_handle_close_regs = cur->next;
+            return cb;
+        }
+        prev = cur;
+        cur  = cur->next;
+    }
+    return NULL;
+}
 
 static void on_goc_handle_close(uv_handle_t* handle)
 {
     GOC_DBG("on_goc_handle_close: handle=%p\n", (void*)handle);
-    goc_handle_close_ctx_t* ctx = (goc_handle_close_ctx_t*)handle->data;
-    uv_close_cb user_cb = ctx ? ctx->user_cb : NULL;
-    handle->data = NULL;
-    gc_handle_unregister(ctx);
+    uv_close_cb user_cb = take_handle_close_cb(handle);
     gc_handle_unregister(handle);
     if (user_cb)
         user_cb(handle);
@@ -1282,17 +1607,36 @@ typedef struct {
 static void on_handle_close_dispatch(void* arg)
 {
     goc_handle_close_dispatch_t* d = (goc_handle_close_dispatch_t*)arg;
-    GOC_DBG("on_handle_close_dispatch: target=%p\n", (void*)d->target);
-    goc_handle_close_ctx_t* ctx = (goc_handle_close_ctx_t*)goc_malloc(
-                                      sizeof(goc_handle_close_ctx_t));
-    ctx->user_cb    = d->user_cb;
-    gc_handle_register(ctx);
-    d->target->data = ctx;
+    GOC_DBG("on_handle_close_dispatch: target=%p loop=%p type=%s active=%d has_ref=%d closing=%d\n",
+            (void*)d->target,
+            d->target ? (void*)d->target->loop : NULL,
+            d->target ? uv_handle_type_name(uv_handle_get_type(d->target)) : "<null>",
+            d->target ? uv_is_active(d->target) : -1,
+            d->target ? uv_has_ref(d->target) : -1,
+            (!d->target) ? -1 : uv_is_closing(d->target));
+    if (!d->target || uv_is_closing(d->target)) {
+        GOC_DBG("on_handle_close_dispatch: target already closing (or NULL), skipping uv_close\n");
+        return;
+    }
+    /* Extra hardening: reject handles that were never properly initialized.
+     * type==UV_UNKNOWN_HANDLE or loop==NULL means uv_tcp_init was never called
+     * (or the handle was zeroed/freed), and passing such a handle to uv_close
+     * would violate libuv's uv__has_active_reqs invariant. */
+    if (d->target->type == UV_UNKNOWN_HANDLE || d->target->loop == NULL) {
+        GOC_DBG("on_handle_close_dispatch: invalid/uninitialized target=%p type=%d loop=%p, skipping uv_close\n",
+            (void*)d->target, (int)d->target->type, (void*)d->target->loop);
+        return;
+    }
+    register_handle_close_cb(d->target, d->user_cb);
     uv_close(d->target, on_goc_handle_close);
 }
 
 void goc_io_handle_close(uv_handle_t* handle, uv_close_cb cb)
 {
+    if (!handle) {
+        GOC_DBG("goc_io_handle_close: called with NULL handle – ignoring\n");
+        return;
+    }
     goc_handle_close_dispatch_t* d = (goc_handle_close_dispatch_t*)goc_malloc(
                                          sizeof(goc_handle_close_dispatch_t));
     d->target  = handle;
@@ -1507,6 +1851,31 @@ typedef struct {
     int       is_tcp; /* 1=tcp 0=pipe */
 } goc_server_ctx_t;
 
+/* Called by loop_process_pending_put when an accepted-connection put is
+ * dropped because the accept channel was closed (server shutting down).
+ * Closes the server-side handle so the client receives FIN/RST instead of
+ * hanging indefinitely waiting for data that will never arrive. */
+
+// Cleanup callback for accepted TCP connection
+static void on_accepted_tcp_dropped(goc_status_t ok, void* ud)
+{
+    if (ok != GOC_OK) {
+        uv_tcp_t* conn = (uv_tcp_t*)ud;
+        gc_handle_unregister(conn);
+        uv_close((uv_handle_t*)conn, NULL);
+    }
+}
+
+// Cleanup callback for accepted pipe connection
+static void on_accepted_pipe_dropped(goc_status_t ok, void* ud)
+{
+    if (ok != GOC_OK) {
+        uv_pipe_t* conn = (uv_pipe_t*)ud;
+        gc_handle_unregister(conn);
+        uv_close((uv_handle_t*)conn, NULL);
+    }
+}
+
 static void on_server_connection(uv_stream_t* server, int status)
 {
     GOC_DBG("on_server_connection: server=%p status=%d\n", (void*)server, status);
@@ -1533,7 +1902,12 @@ static void on_server_connection(uv_stream_t* server, int status)
             uv_close((uv_handle_t*)client, NULL);
             return;
         }
-        goc_put_cb(ctx->ch, client, NULL, NULL);
+        if (goc_chan_is_closing(ctx->ch)) {
+            gc_handle_unregister(client);
+            uv_close((uv_handle_t*)client, NULL);
+            return;
+        }
+        goc_put_cb(ctx->ch, client, on_accepted_tcp_dropped, client);
     } else {
         uv_pipe_t* client = (uv_pipe_t*)goc_malloc(sizeof(uv_pipe_t));
         int rc = uv_pipe_init(g_loop, client, 0);
@@ -1549,7 +1923,12 @@ static void on_server_connection(uv_stream_t* server, int status)
             uv_close((uv_handle_t*)client, NULL);
             return;
         }
-        goc_put_cb(ctx->ch, client, NULL, NULL);
+        if (goc_chan_is_closing(ctx->ch)) {
+            gc_handle_unregister(client);
+            uv_close((uv_handle_t*)client, NULL);
+            return;
+        }
+        goc_put_cb(ctx->ch, client, on_accepted_pipe_dropped, client);
     }
 }
 

--- a/src/goc_stats.c
+++ b/src/goc_stats.c
@@ -154,24 +154,25 @@ static void goc_stats_default_callback(const goc_stats_event_t *ev, void *ud) {
     printf("[goc_stats] %s @ %llu: ", type, (unsigned long long)ev->timestamp);
     switch (ev->type) {
         case GOC_STATS_EVENT_POOL_STATUS:
-            printf("pool=%p status=%d threads=%d\n",
+            printf("pool=%d status=%d threads=%d\n",
                    ev->data.pool.id, ev->data.pool.status, ev->data.pool.thread_count);
             break;
         case GOC_STATS_EVENT_WORKER_STATUS:
             if (ev->data.worker.status == GOC_WORKER_STOPPED)
-                printf("id=%d pool=%p status=%d pending=%d steals=%llu/%llu\n",
+                printf("id=%d pool=%d status=%d pending=%d steals=%llu/%llu\n",
                        ev->data.worker.id, ev->data.worker.pool_id,
                        ev->data.worker.status, ev->data.worker.pending_jobs,
                        (unsigned long long)ev->data.worker.steal_successes,
                        (unsigned long long)ev->data.worker.steal_attempts);
             else
-                printf("id=%d pool=%p status=%d pending=%d\n",
+                printf("id=%d pool=%d status=%d pending=%d\n",
                        ev->data.worker.id, ev->data.worker.pool_id,
                        ev->data.worker.status, ev->data.worker.pending_jobs);
             break;
         case GOC_STATS_EVENT_FIBER_STATUS:
-            printf("id=%d last_worker=%d status=%d\n",
-                   ev->data.fiber.id, ev->data.fiber.last_worker_id, ev->data.fiber.status);
+             printf("id=%d last_worker=%d last_pool=%d status=%d\n",
+                 ev->data.fiber.id, ev->data.fiber.last_worker_id,
+                 ev->data.fiber.last_pool_id, ev->data.fiber.status);
             break;
         case GOC_STATS_EVENT_CHANNEL_STATUS:
             if (ev->data.channel.status == 0)
@@ -291,7 +292,7 @@ static void goc_stats_dispatch(const goc_stats_event_t *ev) {
     uv_async_send(g_stats_async);
 }
 
-void goc_stats_submit_event_pool(void *id, int status, int thread_count) {
+void goc_stats_submit_event_pool(int id, int status, int thread_count) {
     goc_stats_event_t ev;
     ev.type                   = GOC_STATS_EVENT_POOL_STATUS;
     ev.timestamp              = goc_stats_now();
@@ -301,7 +302,7 @@ void goc_stats_submit_event_pool(void *id, int status, int thread_count) {
     goc_stats_dispatch(&ev);
 }
 
-void goc_stats_submit_event_worker(int id, void *pool_id, int status, int pending_jobs,
+void goc_stats_submit_event_worker(int id, int pool_id, int status, int pending_jobs,
                                    uint64_t steal_attempts, uint64_t steal_successes) {
     goc_stats_event_t ev;
     ev.type                       = GOC_STATS_EVENT_WORKER_STATUS;
@@ -315,12 +316,13 @@ void goc_stats_submit_event_worker(int id, void *pool_id, int status, int pendin
     goc_stats_dispatch(&ev);
 }
 
-void goc_stats_submit_event_fiber(int id, int last_worker_id, int status) {
+void goc_stats_submit_event_fiber(int id, int last_worker_id, int last_pool_id, int status) {
     goc_stats_event_t ev;
     ev.type                      = GOC_STATS_EVENT_FIBER_STATUS;
     ev.timestamp                 = goc_stats_now();
     ev.data.fiber.id             = id;
     ev.data.fiber.last_worker_id = last_worker_id;
+    ev.data.fiber.last_pool_id   = last_pool_id;
     ev.data.fiber.status         = status;
     goc_stats_dispatch(&ev);
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -219,6 +219,9 @@ struct goc_spawn_req {
 void chan_register(goc_chan* ch);
 void chan_unregister(goc_chan* ch);
 
+/* channel.c → used by goc_io.c */
+int goc_chan_is_closing(goc_chan* ch);
+
 /* gc.c → called from goc_init (gc.c) */
 void live_uv_handles_init(void);
 
@@ -243,6 +246,7 @@ void* mco_get_suspended_sp(mco_coro* co);
 
 /* pool.c → used by fiber.c, channel.c */
 void post_to_run_queue(goc_pool* pool, goc_entry* entry);
+int  goc_pool_id(goc_pool* pool);
 void pool_submit_spawn(goc_pool* pool,
                        void (*fn)(void*),
                        void* arg,
@@ -276,8 +280,10 @@ static inline bool try_claim_wake(goc_entry* e) {
 /* loop.c → used by channel.c, alts.c, timeout.c, gc.c */
 void loop_init(void);
 void loop_shutdown(void);
+int  goc_loop_is_shutting_down(void);
 void post_callback(goc_entry* entry, void* value);
 void post_on_loop(void (*fn)(void*), void* arg);
+int  post_on_loop_checked(void (*fn)(void*), void* arg);
 
 /* gc.c → used by pool.c, loop.c */
 void live_channels_init(void);

--- a/src/loop.c
+++ b/src/loop.c
@@ -42,6 +42,15 @@ static uv_async_t    *g_wakeup_raw     = NULL;  /* raw pointer behind g_wakeup *
 static uv_async_t    *g_shutdown_async = NULL;
 static uv_thread_t    g_loop_thread;
 static mpsc_queue_t   g_cb_queue;
+static uv_mutex_t     g_loop_submit_lock;
+
+typedef enum {
+    GOC_LOOP_STATE_STOPPED = 0,
+    GOC_LOOP_STATE_RUNNING = 1,
+    GOC_LOOP_STATE_SHUTTING_DOWN = 2,
+} goc_loop_state_t;
+
+static _Atomic int g_loop_state = GOC_LOOP_STATE_STOPPED;
 
 /* Loop-thread drain reentrancy guard.
  * on_wakeup may trigger callbacks that enqueue more work; avoid recursively
@@ -190,6 +199,44 @@ void post_on_loop(void (*fn)(void*), void* arg)
     post_callback(e, NULL);
 }
 
+int post_on_loop_checked(void (*fn)(void*), void* arg)
+{
+    int rc = 0;
+
+    uv_mutex_lock(&g_loop_submit_lock);
+    if (atomic_load_explicit(&g_loop_state, memory_order_acquire) !=
+        GOC_LOOP_STATE_RUNNING) {
+        rc = UV_ECANCELED;
+    } else {
+        goc_loop_task_t* task =
+            (goc_loop_task_t*)goc_malloc(sizeof(goc_loop_task_t));
+        task->fn  = fn;
+        task->arg = arg;
+
+        goc_entry* e = (goc_entry*)goc_malloc(sizeof(goc_entry));
+        *e = (goc_entry){ 0 };
+        e->kind = GOC_CALLBACK;
+        e->cb   = on_loop_task_cb;
+        e->ud   = task;
+        post_callback(e, NULL);
+    }
+    uv_mutex_unlock(&g_loop_submit_lock);
+
+    if (rc < 0) {
+        GOC_DBG("post_on_loop_checked: rejected fn=%p arg=%p state=%d rc=%d\n",
+                (void*)fn, arg,
+                atomic_load_explicit(&g_loop_state, memory_order_relaxed),
+                rc);
+    }
+    return rc;
+}
+
+int goc_loop_is_shutting_down(void)
+{
+    return atomic_load_explicit(&g_loop_state, memory_order_acquire) !=
+           GOC_LOOP_STATE_RUNNING;
+}
+
 /* --------------------------------------------------------------------------
  * goc_scheduler — public
  * -------------------------------------------------------------------------- */
@@ -267,6 +314,21 @@ static void loop_process_pending_put(goc_entry *e)
 
     GOC_DBG("loop_process_pending_put: ch=%p closed=%d item_count=%zu takers=%p val=%p\n",
             (void*)ch, ch->closed, ch->item_count, (void*)ch->takers, e->put_val);
+
+    /* Walk taker list to verify each entry is accessible before claim. */
+    {
+        goc_entry *_t = ch->takers;
+        int _i = 0;
+        while (_t) {
+            GOC_DBG("loop_process_pending_put: taker[%d]=%p cancelled=%d woken=%d kind=%d coro=%p\n",
+                    _i++, (void*)_t,
+                    (int)atomic_load_explicit(&_t->cancelled, memory_order_acquire),
+                    (int)atomic_load_explicit(&_t->woken, memory_order_acquire),
+                    (int)_t->kind,
+                    (_t->kind == GOC_FIBER ? (void*)_t->coro : NULL));
+            _t = _t->next;
+        }
+    }
 
     /* Closed: always fail (matches goc_put ordering). */
     if (ch->closed) {
@@ -364,6 +426,9 @@ static void loop_process_pending_take(goc_entry *e)
     }
 
     /* No match yet: park.  wake() → post_callback() will fire cb later. */
+    GOC_DBG("takers_append: ch=%p e=%p kind=%d coro=%p\n",
+            (void*)ch, (void*)e, (int)e->kind,
+            (e->kind == GOC_FIBER ? (void*)e->coro : NULL));
     chan_list_append(&ch->takers, &ch->takers_tail, e);
     uv_mutex_unlock(ch->lock);
 }
@@ -430,6 +495,11 @@ static void on_shutdown_signal(uv_async_t *h)
     (void)h;
     GOC_DBG("on_shutdown_signal: entered\n");
 
+    uv_mutex_lock(&g_loop_submit_lock);
+    atomic_store_explicit(&g_loop_state, GOC_LOOP_STATE_SHUTTING_DOWN,
+                          memory_order_release);
+    uv_mutex_unlock(&g_loop_submit_lock);
+
     /* Fire any remaining pending callbacks before closing. */
     GOC_DBG("on_shutdown_signal: before drain_cb_queue\n");
     drain_cb_queue_guarded();
@@ -483,6 +553,10 @@ static void loop_thread_fn(void *arg)
 
 void loop_init(void)
 {
+    uv_mutex_init(&g_loop_submit_lock);
+    atomic_store_explicit(&g_loop_state, GOC_LOOP_STATE_STOPPED,
+                          memory_order_relaxed);
+
     /* 1. Allocate and initialise the event loop. */
     g_loop = (uv_loop_t *)malloc(sizeof(uv_loop_t));
     assert(g_loop);
@@ -507,6 +581,9 @@ void loop_init(void)
     /* 5. Initialise the MPSC callback queue. */
     cb_queue_init();
 
+    atomic_store_explicit(&g_loop_state, GOC_LOOP_STATE_RUNNING,
+                          memory_order_release);
+
     /* 6. Spawn the loop thread (GC-registered on all platforms via
      *    goc_thread_create — see internal.h). */
     goc_thread_create(&g_loop_thread, loop_thread_fn, NULL);
@@ -514,7 +591,16 @@ void loop_init(void)
 
 void loop_shutdown(void)
 {
+    GOC_DBG("loop_shutdown: begin depth=%zu hwm=%zu state=%d\n",
+            atomic_load_explicit(&g_cb_queue_depth, memory_order_relaxed),
+            atomic_load_explicit(&g_cb_queue_hwm, memory_order_relaxed),
+            atomic_load_explicit(&g_loop_state, memory_order_relaxed));
     GOC_DBG("loop_shutdown: sending shutdown async\n");
+
+    uv_mutex_lock(&g_loop_submit_lock);
+    atomic_store_explicit(&g_loop_state, GOC_LOOP_STATE_SHUTTING_DOWN,
+                          memory_order_release);
+    uv_mutex_unlock(&g_loop_submit_lock);
 
     /* Signal the loop thread to drain, close handles, and exit. */
     int rcs = uv_async_send(g_shutdown_async);
@@ -523,10 +609,16 @@ void loop_shutdown(void)
     GOC_DBG("loop_shutdown: joining loop thread\n");
     /* Wait for the loop thread to finish. */
     goc_thread_join(&g_loop_thread);
-    GOC_DBG("loop_shutdown: done\n");
+        GOC_DBG("loop_shutdown: joined depth=%zu hwm=%zu\n",
+            atomic_load_explicit(&g_cb_queue_depth, memory_order_relaxed),
+            atomic_load_explicit(&g_cb_queue_hwm, memory_order_relaxed));
+        GOC_DBG("loop_shutdown: done\n");
 
     /* All handles are closed; the loop should be idle. */
     assert(uv_loop_close(g_loop) == 0);
+    uv_mutex_destroy(&g_loop_submit_lock);
+    atomic_store_explicit(&g_loop_state, GOC_LOOP_STATE_STOPPED,
+                          memory_order_release);
     free(g_loop);
     g_loop = NULL;
 }

--- a/src/pool.c
+++ b/src/pool.c
@@ -50,12 +50,14 @@ static _Atomic uint64_t g_steal_attempts  = 0;
 static _Atomic uint64_t g_steal_successes = 0;
 static _Atomic uint64_t g_steal_misses    = 0;
 static _Atomic uint64_t g_idle_wakeups    = 0;
+static _Atomic int      g_pool_id_counter = 0;
 
 /* -------------------------------------------------------------------------
  * goc_pool — full definition (opaque outside pool.c)
  * ---------------------------------------------------------------------- */
 
 struct goc_pool {
+    int                id;
     goc_worker*        workers;
     size_t             thread_count;
     size_t             max_live_fibers;
@@ -116,9 +118,14 @@ void pool_registry_destroy_all(void) {
     g_pool_registry_len = 0;
     uv_mutex_unlock(&g_pool_registry_mutex);
 
+    GOC_DBG("pool_registry_destroy_all: destroying %zu pools\n", len);
+
     for (size_t i = 0; i < len; i++) {
+        GOC_DBG("pool_registry_destroy_all: destroy[%zu/%zu] pool=%p id=%d\n",
+                i + 1, len, (void*)snap[i], snap[i] ? snap[i]->id : -1);
         goc_pool_destroy(snap[i]);
     }
+    GOC_DBG("pool_registry_destroy_all: all pools destroyed\n");
     free(snap);
 
     uv_mutex_destroy(&g_pool_registry_mutex);
@@ -209,6 +216,13 @@ static void pool_enqueue_spawn_locked(goc_pool* pool, goc_spawn_req* req) {
     pool->pending_spawn_tail = req;
 }
 
+static size_t pool_pending_spawn_count_locked(const goc_pool* pool) {
+    size_t n = 0;
+    for (const goc_spawn_req* p = pool->pending_spawn_head; p != NULL; p = p->next)
+        n++;
+    return n;
+}
+
 static goc_spawn_req* pool_collect_admitted_spawns_locked(goc_pool* pool) {
     goc_spawn_req* admitted_head = NULL;
     goc_spawn_req* admitted_tail = NULL;
@@ -277,7 +291,7 @@ void pool_submit_spawn(goc_pool* pool,
         GOC_STATS_WORKER_STATUS(
             (int)atomic_load_explicit(&pool->next_push_idx, memory_order_relaxed)
                  % (int)pool->thread_count,
-            pool, GOC_WORKER_RUNNING, (int)live, 0, 0);
+            pool->id, GOC_WORKER_RUNNING, (int)live, 0, 0);
         post_to_run_queue(pool, entry);
         return;
     }
@@ -404,14 +418,14 @@ static void pool_worker_fn(void* arg) {
             goto run;
         }
 
-        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_IDLE, (int)pool->live_count, 0, 0);
+        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool->id, GOC_WORKER_IDLE, (int)pool->live_count, 0, 0);
         uv_sem_wait(&tl_worker->idle_sem);
 #ifdef GOC_ENABLE_STATS
         atomic_fetch_add_explicit(&tl_worker->idle_wakeups, 1, memory_order_relaxed);
         atomic_fetch_add_explicit(&g_idle_wakeups,           1, memory_order_relaxed);
 #endif
         atomic_fetch_sub_explicit(&pool->idle_count, 1, memory_order_relaxed);
-        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_RUNNING, (int)pool->live_count, 0, 0);
+        GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool->id, GOC_WORKER_RUNNING, (int)pool->live_count, 0, 0);
         continue;   /* re-check shutdown and try again */
 
 run:
@@ -427,6 +441,13 @@ run:
          * stable handle (`coro`) across the call; the mco_coro object remains
          * valid until mco_destroy. */
         mco_coro* coro = entry->coro;
+
+        GOC_DBG("pool_worker_fn: pre-resume coro=%p status=%d\n",
+                (void*)coro,
+                coro ? (int)mco_status(coro) : -1);
+        GOC_DBG("pool_worker_fn: pre-resume stack_base=%p stack_size=%zu\n",
+                coro ? (void*)coro->stack_base : NULL,
+                coro ? coro->stack_size : 0);
 
         /* Redirect GC stack scan to the fiber's stack for the duration of
          * mco_resume (see DESIGN.md §GC Stack Bottom Redirect). */
@@ -488,12 +509,12 @@ run:
             uv_cond_broadcast(&pool->drain_cond);
             uv_mutex_unlock(&pool->drain_mutex);
 
-            GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_RUNNING, (int)pool->live_count, 0, 0);
+            GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool->id, GOC_WORKER_RUNNING, (int)pool->live_count, 0, 0);
             pool_dispatch_spawn_list(pool, admitted);
         }
     }
 
-    GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool, GOC_WORKER_STOPPED, 0,
+    GOC_STATS_WORKER_STATUS((int)tl_worker->index, pool->id, GOC_WORKER_STOPPED, 0,
                             atomic_load_explicit(&tl_worker->steal_attempts,  memory_order_relaxed),
                             atomic_load_explicit(&tl_worker->steal_successes, memory_order_relaxed));
     tl_worker = NULL;
@@ -577,6 +598,7 @@ goc_pool* goc_pool_make(size_t threads) {
     goc_pool* pool = malloc(sizeof(goc_pool));
     memset(pool, 0, sizeof(goc_pool));
 
+    pool->id           = atomic_fetch_add_explicit(&g_pool_id_counter, 1, memory_order_relaxed);
     pool->thread_count = threads;
     pool->max_live_fibers = pool_default_max_live_fibers();
     pool->workers      = malloc(threads * sizeof(goc_worker));
@@ -612,10 +634,10 @@ goc_pool* goc_pool_make(size_t threads) {
                     i + 1, threads, rc);
             abort();
         }
-        GOC_STATS_WORKER_STATUS((int)i, pool, GOC_WORKER_CREATED, 0, 0, 0);
+        GOC_STATS_WORKER_STATUS((int)i, pool->id, GOC_WORKER_CREATED, 0, 0, 0);
     }
 
-    GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_CREATED, (int)threads);
+    GOC_STATS_POOL_STATUS(pool->id, GOC_POOL_CREATED, (int)threads);
     registry_add(pool);
     return pool;
 }
@@ -626,15 +648,41 @@ goc_pool* goc_pool_make(size_t threads) {
 
 void goc_pool_destroy(goc_pool* pool) {
     pool_abort_if_called_from_worker(pool, "goc_pool_destroy");
-    GOC_STATS_POOL_STATUS(goc_box_int(pool), GOC_POOL_DESTROYED, (int)pool->thread_count);
+    GOC_STATS_POOL_STATUS(pool->id, GOC_POOL_DESTROYED, (int)pool->thread_count);
 
     /* 1. Wait for all live fibers to exit (live_count reaches zero). */
     uv_mutex_lock(&pool->drain_mutex);
-    GOC_DBG("goc_pool_destroy: waiting for live_count=%zu\n", pool->live_count);
+    GOC_DBG("goc_pool_destroy: begin drain pool=%p id=%d live=%zu resident=%zu pending_spawn=%zu idle=%zu\n",
+            (void*)pool,
+            pool->id,
+            pool->live_count,
+            pool->resident_count,
+            pool_pending_spawn_count_locked(pool),
+            atomic_load_explicit(&pool->idle_count, memory_order_relaxed));
     while (pool->live_count > 0) {
-        uv_cond_wait(&pool->drain_cond, &pool->drain_mutex);
-        GOC_DBG("goc_pool_destroy: cond_wait returned live_count=%zu\n", pool->live_count);
+        int rc = uv_cond_timedwait(&pool->drain_cond,
+                                   &pool->drain_mutex,
+                                   1000000000ULL /* 1s heartbeat */);
+        if (rc == UV_ETIMEDOUT) {
+            GOC_DBG("goc_pool_destroy: still draining pool=%p id=%d live=%zu resident=%zu pending_spawn=%zu idle=%zu shutdown=%d\n",
+                    (void*)pool,
+                    pool->id,
+                    pool->live_count,
+                    pool->resident_count,
+                    pool_pending_spawn_count_locked(pool),
+                    atomic_load_explicit(&pool->idle_count, memory_order_relaxed),
+                    atomic_load_explicit(&pool->shutdown, memory_order_relaxed));
+        } else {
+            GOC_DBG("goc_pool_destroy: drain wake pool=%p id=%d live=%zu resident=%zu pending_spawn=%zu rc=%d\n",
+                    (void*)pool,
+                    pool->id,
+                    pool->live_count,
+                    pool->resident_count,
+                    pool_pending_spawn_count_locked(pool),
+                    rc);
+        }
     }
+    GOC_DBG("goc_pool_destroy: drain complete pool=%p id=%d\n", (void*)pool, pool->id);
     uv_mutex_unlock(&pool->drain_mutex);
 
     /* 2. Signal workers to exit. */
@@ -750,4 +798,8 @@ void goc_pool_get_steal_stats(uint64_t *attempts, uint64_t *successes,
 void pool_wait_all_idle(goc_pool* pool, size_t n) {
     while (atomic_load_explicit(&pool->idle_count, memory_order_seq_cst) < n)
         uv_sleep(0);
+}
+
+int goc_pool_id(goc_pool* pool) {
+    return pool ? pool->id : -1;
 }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -19,6 +19,7 @@
 #include "../include/goc.h"
 #include "../include/goc_stats.h"
 #include "internal.h"
+#include "channel_internal.h"
 
 /* Lifetime timeout counters — relaxed atomics, read via accessor at teardown */
 static _Atomic uint64_t g_timeout_allocations = 0;
@@ -37,7 +38,41 @@ typedef struct {
 typedef struct goc_timeout_timer_ctx {
     uv_timer_t timer;         /* MUST be first member — freed from uv_close callback */
     goc_chan*  ch;
+    _Atomic int start_state;  /* 0=not-started, 1=started, 2=closed */
+    _Atomic int cancel_requested;
 } goc_timeout_timer_ctx;
+
+static void unregister_handle_cb(uv_handle_t* h);
+
+static void on_cancel_timer(void* arg)
+{
+    goc_timeout_timer_ctx* tctx = (goc_timeout_timer_ctx*)arg;
+    int state = atomic_load_explicit(&tctx->start_state, memory_order_acquire);
+
+    GOC_DBG("on_cancel_timer: tctx=%p timer=%p ch=%p state=%d cancel=%d\n",
+            (void*)tctx, (void*)&tctx->timer, (void*)tctx->ch, state,
+            atomic_load_explicit(&tctx->cancel_requested, memory_order_acquire));
+
+    if (state != 1)
+        return;
+
+    if (uv_is_closing((uv_handle_t*)&tctx->timer))
+        return;
+
+    uv_timer_stop(&tctx->timer);
+    atomic_store_explicit(&tctx->start_state, 2, memory_order_release);
+    uv_close((uv_handle_t*)&tctx->timer, unregister_handle_cb);
+}
+
+static void on_timeout_channel_closed(void* ud)
+{
+    goc_timeout_timer_ctx* tctx = (goc_timeout_timer_ctx*)ud;
+    atomic_store_explicit(&tctx->cancel_requested, 1, memory_order_release);
+    GOC_DBG("on_timeout_channel_closed: tctx=%p timer=%p ch=%p state=%d\n",
+            (void*)tctx, (void*)&tctx->timer, (void*)tctx->ch,
+            atomic_load_explicit(&tctx->start_state, memory_order_acquire));
+    post_on_loop(on_cancel_timer, tctx);
+}
 
 /* -------------------------------------------------------------------------
  * Static callbacks (loop thread)
@@ -52,6 +87,7 @@ static void on_timeout(uv_timer_t* t)
     GOC_DBG("on_timeout: timer=%p ch=%p\n", (void*)t, (void*)ch);
     atomic_fetch_add_explicit(&g_timeout_expirations, 1, memory_order_relaxed);
     goc_close(ch);
+    atomic_store_explicit(&tctx->start_state, 2, memory_order_release);
     uv_close((uv_handle_t*)t, unregister_handle_cb);
 }
 
@@ -72,6 +108,13 @@ static void on_start_timer(void* arg)
     uint64_t elapsed_ms = elapsed_ns / 1000000ULL;
     uint64_t remaining  = (elapsed_ms < req->ms) ? (req->ms - elapsed_ms) : 0;
 
+    if (atomic_load_explicit(&req->timer_ctx->cancel_requested, memory_order_acquire)) {
+        GOC_DBG("on_start_timer: cancel requested before init req=%p tctx=%p ch=%p\n",
+                (void*)req, (void*)req->timer_ctx, (void*)req->timer_ctx->ch);
+        gc_handle_unregister(req->timer_ctx);
+        return;
+    }
+
     int rc = uv_timer_init(g_loop, &req->timer_ctx->timer);
     GOC_DBG("on_start_timer: uv_timer_init timer=%p rc=%d remaining=%llu\n",
             (void*)&req->timer_ctx->timer, rc, (unsigned long long)remaining);
@@ -81,10 +124,21 @@ static void on_start_timer(void* arg)
         return;
     }
 
+    atomic_store_explicit(&req->timer_ctx->start_state, 1, memory_order_release);
+
+    if (atomic_load_explicit(&req->timer_ctx->cancel_requested, memory_order_acquire)) {
+        GOC_DBG("on_start_timer: cancel requested after init req=%p tctx=%p timer=%p\n",
+                (void*)req, (void*)req->timer_ctx, (void*)&req->timer_ctx->timer);
+        atomic_store_explicit(&req->timer_ctx->start_state, 2, memory_order_release);
+        uv_close((uv_handle_t*)&req->timer_ctx->timer, unregister_handle_cb);
+        return;
+    }
+
     rc = uv_timer_start(&req->timer_ctx->timer, on_timeout, remaining, 0);  /* one-shot */
     GOC_DBG("on_start_timer: uv_timer_start rc=%d\n", rc);
     if (rc < 0) {
         goc_close(req->timer_ctx->ch);
+        atomic_store_explicit(&req->timer_ctx->start_state, 2, memory_order_release);
         uv_close((uv_handle_t*)&req->timer_ctx->timer, unregister_handle_cb);
     }
 }
@@ -102,6 +156,8 @@ goc_chan* goc_timeout(uint64_t ms)
             (unsigned long long)ms, (void*)ch, (void*)req, (void*)tctx);
 
     tctx->ch = ch;
+        atomic_store_explicit(&tctx->start_state, 0, memory_order_relaxed);
+        atomic_store_explicit(&tctx->cancel_requested, 0, memory_order_relaxed);
 
     req->timer_ctx   = tctx;
     req->ms          = ms;
@@ -109,6 +165,7 @@ goc_chan* goc_timeout(uint64_t ms)
 
     /* Register tctx: it holds the timer handle and the channel pointer. */
     gc_handle_register(tctx);
+    chan_set_on_close(ch, on_timeout_channel_closed, tctx);
 
     atomic_fetch_add_explicit(&g_timeout_allocations, 1, memory_order_relaxed);
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,148 @@
-#! /bin/bash
-rm -rf build/ \
-    && cmake -S . -B build -DGOC_ENABLE_STATS=ON \
-    && cmake --build build \
-    && ctest --test-dir build --output-on-failure
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+LOG_FILE="${LOG_FILE:-test.log}"
+WATCH_MODE="${WATCH:-0}"
+
+# Truncate and stream all output (stdout+stderr) to console and log file.
+exec > >(tee "$LOG_FILE") 2>&1
+
+FAILED_TESTS=()
+
+configure_build() {
+    cmake -S . -B "$BUILD_DIR" \
+        -DGOC_ENABLE_STATS=ON \
+        -DLIBGOC_DEBUG=ON
+}
+
+build_project() {
+    cmake --build "$BUILD_DIR"
+}
+
+collect_failed_tests() {
+    local out_file="$1"
+    mapfile -t FAILED_TESTS < <(
+        sed -n 's/^[[:space:]]*[0-9][0-9]* - \([^[:space:]]*\).*/\1/p' "$out_file"
+    )
+}
+
+run_all_tests() {
+    local out_file
+    out_file="$(mktemp)"
+    if ctest --test-dir "$BUILD_DIR" --output-on-failure | tee "$out_file"; then
+        FAILED_TESTS=()
+        rm -f "$out_file"
+        return 0
+    fi
+    collect_failed_tests "$out_file"
+    rm -f "$out_file"
+    return 1
+}
+
+join_failed_regex() {
+    local regex=""
+    local t
+    for t in "${FAILED_TESTS[@]}"; do
+        if [[ -n "$regex" ]]; then
+            regex+="|"
+        fi
+        regex+="$t"
+    done
+    printf '%s' "$regex"
+}
+
+run_failed_tests() {
+    if [[ ${#FAILED_TESTS[@]} -eq 0 ]]; then
+        echo "No recorded failed tests; running full suite."
+        run_all_tests
+        return $?
+    fi
+
+    local regex
+    regex="$(join_failed_regex)"
+    local out_file
+    out_file="$(mktemp)"
+
+    echo "Re-running failed tests: ${FAILED_TESTS[*]}"
+    if ctest --test-dir "$BUILD_DIR" --output-on-failure -R "^(${regex})$" | tee "$out_file"; then
+        FAILED_TESTS=()
+        rm -f "$out_file"
+        return 0
+    fi
+
+    collect_failed_tests "$out_file"
+    rm -f "$out_file"
+    return 1
+}
+
+watch_signature() {
+    find src include tests -type f \( -name '*.c' -o -name '*.h' \) -print \
+        | LC_ALL=C sort \
+        | while IFS= read -r f; do
+              cksum "$f"
+          done \
+        | cksum \
+        | awk '{print $1":"$2}'
+}
+
+run_cycle() {
+    configure_build && build_project
+    run_all_tests
+    return $?
+}
+
+rm -rf "$BUILD_DIR"
+
+echo "== libgoc test runner =="
+echo "Build dir : $BUILD_DIR"
+echo "Log file  : $LOG_FILE"
+echo "Debug     : LIBGOC_DEBUG=ON"
+echo "Watch mode: $WATCH_MODE"
+
+last_status=0
+if ! run_cycle; then
+    last_status=$?
+fi
+
+if [[ "$WATCH_MODE" == "1" ]]; then
+    echo "Watch mode enabled: waiting for source/header changes under src/, include/, tests/."
+    prev_sig="$(watch_signature)"
+
+    while true; do
+        sleep 1
+        cur_sig="$(watch_signature)"
+        if [[ "$cur_sig" == "$prev_sig" ]]; then
+            continue
+        fi
+
+        prev_sig="$cur_sig"
+        echo
+        echo "== Change detected; rebuilding and running tests =="
+        : > "$LOG_FILE"
+
+        if ! (configure_build && build_project); then
+            echo "Build failed; waiting for next change..."
+            last_status=1
+            continue
+        fi
+
+        if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
+            if run_failed_tests; then
+                last_status=0
+            else
+                last_status=1
+            fi
+        else
+            if run_all_tests; then
+                last_status=0
+            else
+                last_status=1
+            fi
+        fi
+    done
+fi
+
+exit "$last_status"

--- a/tests/test_goc_stats.c
+++ b/tests/test_goc_stats.c
@@ -194,12 +194,14 @@ static const goc_stats_event_t* find_any_worker_status(
 
 static void emit_worker_event(void* arg) {
     (void)arg;
-    GOC_STATS_WORKER_STATUS(/*id=*/42, /*pool_id=*/NULL, GOC_WORKER_RUNNING, /*pending_jobs=*/5, /*steal_att=*/0, /*steal_suc=*/0);
+    GOC_STATS_WORKER_STATUS(/*id=*/42, /*pool_id=*/1234, GOC_WORKER_RUNNING, /*pending_jobs=*/5, /*steal_att=*/0, /*steal_suc=*/0);
 }
 
 static void emit_fiber_event(void* arg) {
     (void)arg;
-    GOC_STATS_FIBER_STATUS(/*id=*/7, /*last_worker_id=*/3, GOC_FIBER_COMPLETED);
+    GOC_STATS_FIBER_STATUS(/*id=*/7, /*last_worker_id=*/3,
+                           /*last_pool_id=*/0xABCD,
+                           GOC_FIBER_COMPLETED);
 }
 
 static void emit_channel_event(void* arg) {
@@ -241,7 +243,7 @@ static void test_s1_3(void) {
     ASSERT(ev->type == GOC_STATS_EVENT_WORKER_STATUS);
     ASSERT(ev->timestamp > 0);
     ASSERT(ev->data.worker.id           == 42);
-    ASSERT(ev->data.worker.pool_id      == NULL);
+    ASSERT(ev->data.worker.pool_id      == 1234);
     ASSERT(ev->data.worker.status       == GOC_WORKER_RUNNING);
     ASSERT(ev->data.worker.pending_jobs == 5);
     /* New: assert steal_attempts == 0 and steal_successes == 0 */
@@ -263,6 +265,7 @@ static void test_s1_4(void) {
     ASSERT(ev->timestamp > 0);
     ASSERT(ev->data.fiber.id             == 7);
     ASSERT(ev->data.fiber.last_worker_id == 3);
+    ASSERT(ev->data.fiber.last_pool_id   == 0xABCD);
     ASSERT(ev->data.fiber.status         == GOC_FIBER_COMPLETED);
     TEST_PASS();
 done:;
@@ -319,12 +322,14 @@ static void test_s2_1(void) {
     const goc_stats_event_t* created = find_any_fiber_created();
     ASSERT(created != NULL);
     ASSERT(created->data.fiber.last_worker_id == -1);
+    ASSERT(created->data.fiber.last_pool_id >= 0);
     ASSERT(created->timestamp > 0);
     int fiber_id = created->data.fiber.id;
 
     const goc_stats_event_t* completed = find_fiber_event(fiber_id, GOC_FIBER_COMPLETED);
     ASSERT(completed != NULL);
     ASSERT(completed->data.fiber.last_worker_id >= 0);
+    ASSERT(completed->data.fiber.last_pool_id == created->data.fiber.last_pool_id);
     ASSERT(completed->timestamp >= created->timestamp);
 
     TEST_PASS();
@@ -393,7 +398,7 @@ static void test_s2_4(void) {
     TEST_BEGIN("S2.4  pool creation and destruction events");
     drain_pending_events();
     goc_pool* pool = goc_pool_make(3);
-    void* pool_id = pool;
+    int pool_id = goc_pool_id(pool);
     const goc_stats_event_t* create_ev = NULL;
     const goc_stats_event_t* destroy_ev = NULL;
     // Find pool created event
@@ -632,7 +637,7 @@ static void test_s5_1(void) {
     drain_pending_events();
 
     goc_pool* pool = goc_pool_make(2);
-    void* pool_id = pool;
+    int pool_id = goc_pool_id(pool);
 
     /* Submit many short fibers to provoke work stealing between the 2 workers.
      * Each fiber emits ~4 events (FIBER_CREATED, FIBER_COMPLETED, join_ch

--- a/tests/test_p06_thread_pool.c
+++ b/tests/test_p06_thread_pool.c
@@ -252,7 +252,19 @@ typedef struct {
     goc_pool* expected_pool;
     done_t*   done;
     bool      ran;
+    bool      cur_pool_ok;
+    bool      cur_or_default_ok;
+    bool      cur_fiber_nonnull;
+    bool      child_pool_ok;
 } p6_1_args_t;
+
+static void test_p6_1_child_fn(void* arg) {
+    p6_1_args_t* a = (p6_1_args_t*)arg;
+    a->child_pool_ok =
+        (goc_current_pool() == a->expected_pool) &&
+        (goc_current_or_default_pool() == a->expected_pool) &&
+        (goc_current_fiber() != NULL);
+}
 
 /*
  * Fiber for P6.1.
@@ -261,6 +273,13 @@ typedef struct {
  */
 static void test_p6_1_fiber_fn(void* arg) {
     p6_1_args_t* a = (p6_1_args_t*)arg;
+    a->cur_pool_ok = (goc_current_pool() == a->expected_pool);
+    a->cur_or_default_ok = (goc_current_or_default_pool() == a->expected_pool);
+    a->cur_fiber_nonnull = (goc_current_fiber() != NULL);
+    (void)goc_current_thread();
+
+    /* goc_go should inherit the current pool when called from a fiber. */
+    goc_take(goc_go(test_p6_1_child_fn, a));
     a->ran = true;
     done_signal(a->done);
 }
@@ -292,6 +311,10 @@ static void test_p6_1(void) {
 
     done_wait(&done);
     ASSERT(args.ran == true);
+    ASSERT(args.cur_pool_ok == true);
+    ASSERT(args.cur_or_default_ok == true);
+    ASSERT(args.cur_fiber_nonnull == true);
+    ASSERT(args.child_pool_ok == true);
 
     /* Join channel must close once the fiber exits. */
     goc_val_t* v = goc_take_sync(join);
@@ -1672,7 +1695,7 @@ static void test_p6_24(void) {
 
     goc_pool* pool = goc_pool_make(2);
     ASSERT(pool != NULL);
-    void* pool_id = pool;
+    int pool_id = -1;
 
     /* Burst of short fibers to provoke work stealing. */
     for (int i = 0; i < 64; i++)
@@ -1686,14 +1709,22 @@ static void test_p6_24(void) {
     uv_mutex_lock(&evbuf.mtx);
     for (size_t i = 0; i < evbuf.count; i++) {
         const goc_stats_event_t* ev = &evbuf.buf[i];
+        if (pool_id < 0 &&
+            ev->type == GOC_STATS_EVENT_POOL_STATUS &&
+            ev->data.pool.status == GOC_POOL_CREATED &&
+            ev->data.pool.thread_count == 2) {
+            pool_id = ev->data.pool.id;
+        }
         if (ev->type != GOC_STATS_EVENT_WORKER_STATUS) continue;
         if (ev->data.worker.status != GOC_WORKER_STOPPED) continue;
+        if (pool_id < 0) continue;
         if (ev->data.worker.pool_id != pool_id) continue;
         ASSERT(ev->data.worker.steal_successes <= ev->data.worker.steal_attempts);
         stopped_found++;
     }
     uv_mutex_unlock(&evbuf.mtx);
 
+    ASSERT(pool_id >= 0);
     ASSERT(stopped_found >= 2);
 
     TEST_PASS();
@@ -1722,7 +1753,7 @@ static void test_p6_25(void) {
 
     goc_pool* pool = goc_pool_make(2);
     ASSERT(pool != NULL);
-    void* pool_id = pool;
+    int pool_id = -1;
 
     for (int i = 0; i < 64; i++)
         goc_go_on(pool, p6_steal_noop, NULL);
@@ -1740,13 +1771,21 @@ static void test_p6_25(void) {
     uv_mutex_lock(&evbuf.mtx);
     for (size_t i = 0; i < evbuf.count; i++) {
         const goc_stats_event_t* ev = &evbuf.buf[i];
+        if (pool_id < 0 &&
+            ev->type == GOC_STATS_EVENT_POOL_STATUS &&
+            ev->data.pool.status == GOC_POOL_CREATED &&
+            ev->data.pool.thread_count == 2) {
+            pool_id = ev->data.pool.id;
+        }
         if (ev->type != GOC_STATS_EVENT_WORKER_STATUS) continue;
         if (ev->data.worker.status != GOC_WORKER_STOPPED) continue;
+        if (pool_id < 0) continue;
         if (ev->data.worker.pool_id != pool_id) continue;
         ev_att_sum += ev->data.worker.steal_attempts;
     }
     uv_mutex_unlock(&evbuf.mtx);
 
+    ASSERT(pool_id >= 0);
     ASSERT((att1 - att0) == ev_att_sum);
 
     TEST_PASS();

--- a/tests/test_p11_http.c
+++ b/tests/test_p11_http.c
@@ -36,7 +36,10 @@
  *   P11.23 Correctness: goc_http_response_t->body_len matches respond_buf len
  *   P11.24 Correctness: custom request headers via opts->headers received
  *   P11.25 Security: CRLF in header value blocked (header-injection)
- *   P11.26 Integration: ping-pong — two servers bounce a counter 500 round trips
+ *   P11.26 Integration: ping-pong — two servers bounce a counter 500 round trips (keep-alive enabled)
+ *   P11.27 Keep-alive: client/server persistent connection handles sequential requests
+ *   P11.28 Regression: fire-and-forget ping-pong survives repeated immediate teardown
+ *   P11.29 Regression: fire-and-forget connect churn survives repeated teardown
  */
 
 #if !defined(_WIN32) && !defined(__APPLE__)
@@ -863,6 +866,7 @@ typedef struct {
     goc_chan* done;
     int       port;
     int       oversized_status;
+    int       oversized_status2;
     int       followup_status;
 } p11_oversize_t;
 
@@ -875,13 +879,21 @@ static void fiber_p11_19(void* arg)
 
     char* big = (char*)calloc(P11_19_BODY_BYTES, 1);
     if (big) {
+        goc_http_request_opts_t* o = goc_http_request_opts();
+        o->keep_alive = 1;
         goc_http_response_t* r1 = (goc_http_response_t*)goc_take(
             goc_http_post_buf(local_url("/ok", a->port),
                               "application/octet-stream",
                               big, P11_19_BODY_BYTES,
-                              goc_http_request_opts()))->val;
+                              o))->val;
+        goc_http_response_t* r2 = (goc_http_response_t*)goc_take(
+            goc_http_post_buf(local_url("/ok", a->port),
+                              "application/octet-stream",
+                              big, P11_19_BODY_BYTES,
+                              o))->val;
         free(big);
         a->oversized_status = r1 ? r1->status : -1;
+        a->oversized_status2 = r2 ? r2->status : -1;
     }
 
     /* Follow-up: server must still accept normal requests after the rejection. */
@@ -907,6 +919,7 @@ static void test_p11_19(void)
     goc_take_sync(args.done);
     /* Server closed without sending a response: status must be 0. */
     ASSERT(args.oversized_status == 0);
+    ASSERT(args.oversized_status2 == 0);
     /* Server must still be live for subsequent requests. */
     ASSERT(args.followup_status == 200);
     TEST_PASS();
@@ -1258,7 +1271,9 @@ static void pp_handler_a(goc_http_ctx_t* ctx)
         return;
     }
     char* msg = goc_sprintf("%d", n + 1);
-    goc_http_post(g_pp_addr_b, "text/plain", msg, goc_http_request_opts());
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(g_pp_addr_b, "text/plain", msg, opts);
 }
 
 /* Server B: receive counter, respond, then forward to A. */
@@ -1267,7 +1282,9 @@ static void pp_handler_b(goc_http_ctx_t* ctx)
     int n = atoi(goc_http_server_body_str(ctx));
     goc_take(goc_http_server_respond(ctx, 200, "text/plain", "ok"));
     char* msg = goc_sprintf("%d", n + 1);
-    goc_http_post(g_pp_addr_a, "text/plain", msg, goc_http_request_opts());
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(g_pp_addr_a, "text/plain", msg, opts);
 }
 
 static void fiber_p11_26(void* arg)
@@ -1290,7 +1307,9 @@ static void fiber_p11_26(void* arg)
     goc_take(ready_b);
 
     /* Fire the first request; the two handlers bounce it back and forth. */
-    goc_http_post(g_pp_addr_a, "text/plain", "0", goc_http_request_opts());
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(g_pp_addr_a, "text/plain", "0", opts);
 
     /* Wait until server A closes pp_done (counter reached ROUNDS). */
     goc_take(a->pp_done);
@@ -1302,7 +1321,7 @@ static void fiber_p11_26(void* arg)
 
 static void test_p11_26(void)
 {
-    TEST_BEGIN("P11.26 Ping-pong: 500 round trips between two servers");
+    TEST_BEGIN("P11.26 Ping-pong: 500 round trips between two servers (keep-alive)");
     p11_pingpong_t args = {
         goc_chan_make(1),   /* test_done */
         next_port(),        /* port_a */
@@ -1316,13 +1335,218 @@ done:;
 }
 
 /* =========================================================================
+ * P11.27 — Keep-alive sequential requests on one persistent connection
+ * ====================================================================== */
+
+typedef struct {
+    goc_chan* done;
+    int       port;
+    int       status1;
+    int       status2;
+} p11_keepalive_t;
+
+static void fiber_p11_27(void* arg)
+{
+    p11_keepalive_t* a = (p11_keepalive_t*)arg;
+    goc_http_server_t* srv = goc_http_server_make(goc_http_server_opts());
+    goc_http_server_route(srv, "GET", "/ping", handler_ping);
+    goc_take(goc_http_server_listen(srv, "127.0.0.1", a->port));
+
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+
+    goc_http_response_t* r1 = (goc_http_response_t*)goc_take(
+        goc_http_get(local_url("/ping", a->port), opts))->val;
+    a->status1 = r1 ? r1->status : -1;
+
+    goc_http_response_t* r2 = (goc_http_response_t*)goc_take(
+        goc_http_get(local_url("/ping", a->port), opts))->val;
+    a->status2 = r2 ? r2->status : -1;
+
+    goc_take(goc_http_server_close(srv));
+    goc_put(a->done, goc_box_int(1));
+}
+
+static void test_p11_27(void)
+{
+    TEST_BEGIN("P11.27 Keep-alive: sequential requests succeed with persistent connection");
+    p11_keepalive_t args;
+    memset(&args, 0, sizeof(args));
+    args.done = goc_chan_make(1);
+    args.port = next_port();
+    goc_go(fiber_p11_27, &args);
+    goc_take_sync(args.done);
+    ASSERT(args.status1 == 200);
+    ASSERT(args.status2 == 200);
+    TEST_PASS();
+done:;
+}
+
+/* =========================================================================
+ * P11.28 — Regression: fire-and-forget ping-pong + immediate teardown
+ *
+ * Replays the original fire-and-forget forwarding behavior (handlers post
+ * outbound relay requests without waiting on the result), then tears both
+ * servers down immediately when the target round count is reached.
+ *
+ * This historically exposed a libuv assertion in write callback processing
+ * under repeated runs. Keep this test as a stress guard for close/write races.
+ * ========================================================================= */
+
+#define P11_28_ITERS  8
+#define P11_28_ROUNDS 250
+
+typedef struct {
+    goc_chan* test_done;
+    int       ok;
+} p11_ff_reg_t;
+
+typedef struct {
+    goc_chan* done;
+    int       rounds;
+    char      url_a[64];
+    char      url_b[64];
+} p11_ff_ctx_t;
+
+static p11_ff_ctx_t* g_ff_ctx = NULL;
+
+static void ff_handler_a(goc_http_ctx_t* ctx)
+{
+    int n = atoi(goc_http_server_body_str(ctx));
+    goc_take(goc_http_server_respond(ctx, 200, "text/plain", "ok"));
+    if (n >= g_ff_ctx->rounds) {
+        goc_close(g_ff_ctx->done);
+        return;
+    }
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(g_ff_ctx->url_b, "text/plain", goc_sprintf("%d", n + 1), opts);
+}
+
+static void ff_handler_b(goc_http_ctx_t* ctx)
+{
+    int n = atoi(goc_http_server_body_str(ctx));
+    goc_take(goc_http_server_respond(ctx, 200, "text/plain", "ok"));
+    goc_http_request_opts_t* opts = goc_http_request_opts();
+    opts->keep_alive = 1;
+    goc_http_post(g_ff_ctx->url_a, "text/plain", goc_sprintf("%d", n + 1), opts);
+}
+
+static void fiber_p11_28(void* arg)
+{
+    p11_ff_reg_t* a = (p11_ff_reg_t*)arg;
+    a->ok = 1;
+
+    for (int i = 0; i < P11_28_ITERS; i++) {
+        int port_a = next_port();
+        int port_b = next_port();
+
+        p11_ff_ctx_t* ctx = (p11_ff_ctx_t*)goc_malloc(sizeof(p11_ff_ctx_t));
+        ctx->done   = goc_chan_make(0);
+        ctx->rounds = P11_28_ROUNDS;
+        snprintf(ctx->url_a, sizeof(ctx->url_a), "http://127.0.0.1:%d/ping", port_a);
+        snprintf(ctx->url_b, sizeof(ctx->url_b), "http://127.0.0.1:%d/ping", port_b);
+        g_ff_ctx = ctx;
+
+        goc_http_server_t* srv_a = goc_http_server_make(goc_http_server_opts());
+        goc_http_server_t* srv_b = goc_http_server_make(goc_http_server_opts());
+        goc_http_server_route(srv_a, "POST", "/ping", ff_handler_a);
+        goc_http_server_route(srv_b, "POST", "/ping", ff_handler_b);
+
+        goc_take(goc_http_server_listen(srv_a, "127.0.0.1", port_a));
+        goc_take(goc_http_server_listen(srv_b, "127.0.0.1", port_b));
+
+        goc_http_request_opts_t* opts = goc_http_request_opts();
+        opts->keep_alive = 1;
+        goc_http_post(ctx->url_a, "text/plain", "0", opts);
+
+        goc_take(ctx->done);
+
+        /* Intentional immediate teardown: this is the race window we guard. */
+        goc_take(goc_http_server_close(srv_a));
+        goc_take(goc_http_server_close(srv_b));
+    }
+
+    goc_put(a->test_done, goc_box_int(1));
+}
+
+static void test_p11_28(void)
+{
+    TEST_BEGIN("P11.28 Regression: fire-and-forget ping-pong survives repeated teardown");
+    p11_ff_reg_t args;
+    memset(&args, 0, sizeof(args));
+    args.test_done = goc_chan_make(1);
+    goc_go(fiber_p11_28, &args);
+    goc_take_sync(args.test_done);
+    ASSERT(args.ok == 1);
+    TEST_PASS();
+done:;
+}
+
+/* =========================================================================
+ * P11.29 — Regression: fire-and-forget connect churn + immediate teardown
+ *
+ * Stresses outbound connect/write callback lifetimes by launching many
+ * fire-and-forget requests, then tearing the server down quickly. The goal is
+ * to catch connect/write lifecycle regressions (including libuv req asserts).
+ * ========================================================================= */
+
+#define P11_29_ITERS     6
+#define P11_29_REQUESTS  600
+
+typedef struct {
+    goc_chan* done;
+    int       ok;
+} p11_ff_churn_t;
+
+static void fiber_p11_29(void* arg)
+{
+    p11_ff_churn_t* a = (p11_ff_churn_t*)arg;
+    a->ok = 1;
+
+    for (int iter = 0; iter < P11_29_ITERS; iter++) {
+        int port = next_port();
+        goc_http_server_t* srv = goc_http_server_make(goc_http_server_opts());
+        goc_http_server_route(srv, "POST", "/ok", handler_ping);
+        goc_take(goc_http_server_listen(srv, "127.0.0.1", port));
+
+        const char* url = local_url("/ok", port);
+        for (int i = 0; i < P11_29_REQUESTS; i++) {
+            goc_http_request_opts_t* opts = goc_http_request_opts();
+            opts->keep_alive = 0; /* force connect churn */
+            goc_http_post(url, "text/plain", "x", opts);
+        }
+
+        /* Keep this intentionally short to maximize overlap with in-flight IO.
+         */
+        goc_take(goc_timeout(15));
+        goc_take(goc_http_server_close(srv));
+    }
+
+    goc_put(a->done, goc_box_int(1));
+}
+
+static void test_p11_29(void)
+{
+    TEST_BEGIN("P11.29 Regression: fire-and-forget connect churn survives repeated teardown");
+    p11_ff_churn_t args;
+    memset(&args, 0, sizeof(args));
+    args.done = goc_chan_make(1);
+    goc_go(fiber_p11_29, &args);
+    goc_take_sync(args.done);
+    ASSERT(args.ok == 1);
+    TEST_PASS();
+done:;
+}
+
+/* =========================================================================
  * main
  * ====================================================================== */
 
 int main(void)
 {
     install_crash_handler();
-    goc_test_arm_watchdog(60);
+    goc_test_arm_watchdog(90);
 
     /* Keep HTTP stress deterministic in CI/local loops by capping pool
      * parallelism for this test process. High worker counts amplify scheduler
@@ -1363,6 +1587,9 @@ int main(void)
     test_p11_24();
     test_p11_25();
     test_p11_26();
+    test_p11_27();
+    test_p11_28();
+    test_p11_29();
 
 
     printf("\n%d/%d tests passed", g_tests_passed, g_tests_run);


### PR DESCRIPTION
Fixes #90, #94, #89

## PR Summary

**HTTP keep-alive, server shutdown drain, new pool-context APIs, and I/O robustness fixes**

This branch extends the runtime and HTTP layer with several related improvements:

- **HTTP keep-alive** (`opts->keep_alive`): outbound client requests can reuse a per-worker-thread TCP connection to the same host:port, eliminating redundant DNS lookups and TCP handshakes for repeated calls (e.g. the ping-pong benchmark). Uses HTTP/1.1 with `Connection: keep-alive`; falls back to close if the server responds with `Connection: close` or no `Content-Length`.
- **HTTP server shutdown drain**: `goc_http_server_close` now waits for all in-flight connection fibers to finish before delivering its result channel. Prevents use-after-free when the caller tears down immediately after close.
- **Pool-context API**: four new public functions — `goc_current_pool()`, `goc_current_or_default_pool()`, `goc_current_thread()`, `goc_current_fiber()` — expose the calling fiber's runtime context. `goc_go()` now spawns on the current pool (not always the default pool), and HTTP request/server opts default to `goc_current_or_default_pool()`.
- **Stats IDs as `int`**: pool and worker `pool_id` fields changed from `void*` to `int` (monotonic IDs). Fiber events gain `last_pool_id`. All macros and docs updated.
- **Numeric-host fast path**: outbound HTTP requests skip DNS for numeric IPv4/IPv6 hosts.
- **DNS tracing**: bounded `[DNS_TRACE]` diagnostic log in `goc_io_getaddrinfo` for submit/callback imbalance debugging. DNS and write ctx allocations moved from `goc_malloc` to plain `malloc`/`free` to avoid GC registration overhead for short-lived request contexts.
- **Write pre-flight guard**: `goc_io_write` rejects writes to closing handles or a shutting-down loop immediately, preventing libuv assertion failures.
- **TCP/pipe server cleanup**: `on_server_connection` now registers per-connection close callbacks, fixing a handle resource leak on drop.
- **test.sh rewrite**: watch mode, log file tee, selective re-run of failed tests, `LIBGOC_DEBUG=ON` build flag.
- **New HTTP tests**: P11.27 (keep-alive sequential requests), P11.28/P11.29 (fire-and-forget teardown regression).
- **Docs**: README, DESIGN.md, HTTP.md, TELEMETRY.md all updated to match new APIs and behaviour.